### PR TITLE
Changes in Hyperspectral_{metadata, calculation}.py

### DIFF
--- a/hyperspectral/hyperspectral_calculation.py
+++ b/hyperspectral/hyperspectral_calculation.py
@@ -54,9 +54,13 @@ def pixel2Geographic(jsonFileLocation, headerFileLocation, cameraOption):
         if "position x [m]" in master["gantry_system_variable_metadata"]:
             x_gantry_pos = float(master["gantry_system_variable_metadata"]["position x [m]"])
             y_gantry_pos = float(master["gantry_system_variable_metadata"]["position y [m]"])
-        else:
+
+        elif "Position x [m]" in master["gantry_system_variable_metadata"]:
             x_gantry_pos = float(master["gantry_system_variable_metadata"]["Position x [m]"])
             y_gantry_pos = float(master["gantry_system_variable_metadata"]["Position y [m]"])
+
+        else: # We notice that there are cases that no position data available
+            return 0, 0, [0]*4 , ""
 
         x_camera_pos = 1.9 # From https://github.com/terraref/reference-data/issues/32
         y_camera_pos = 0.855

--- a/hyperspectral/hyperspectral_calculation.py
+++ b/hyperspectral/hyperspectral_calculation.py
@@ -60,7 +60,7 @@ def pixel2Geographic(jsonFileLocation, headerFileLocation, cameraOption):
             y_gantry_pos = float(master["gantry_system_variable_metadata"]["Position y [m]"])
 
         else: # We notice that there are cases that no position data available
-            return [0], [0], [0]*4 , ""
+            return [0], [0], ["0.0"]*4 , ""
 
         x_camera_pos = 1.9 # From https://github.com/terraref/reference-data/issues/32
         y_camera_pos = 0.855

--- a/hyperspectral/hyperspectral_calculation.py
+++ b/hyperspectral/hyperspectral_calculation.py
@@ -60,7 +60,7 @@ def pixel2Geographic(jsonFileLocation, headerFileLocation, cameraOption):
             y_gantry_pos = float(master["gantry_system_variable_metadata"]["Position y [m]"])
 
         else: # We notice that there are cases that no position data available
-            return [0], [0], ["0,0"]*4 , ""
+            return [0], [0], ["0, 0"]*4 , ""
 
         x_camera_pos = 1.9 # From https://github.com/terraref/reference-data/issues/32
         y_camera_pos = 0.855

--- a/hyperspectral/hyperspectral_calculation.py
+++ b/hyperspectral/hyperspectral_calculation.py
@@ -60,7 +60,7 @@ def pixel2Geographic(jsonFileLocation, headerFileLocation, cameraOption):
             y_gantry_pos = float(master["gantry_system_variable_metadata"]["Position y [m]"])
 
         else: # We notice that there are cases that no position data available
-            return [0], [0], ["0.0"]*4 , ""
+            return [0], [0], ["0,0"]*4 , ""
 
         x_camera_pos = 1.9 # From https://github.com/terraref/reference-data/issues/32
         y_camera_pos = 0.855

--- a/hyperspectral/hyperspectral_calculation.py
+++ b/hyperspectral/hyperspectral_calculation.py
@@ -60,7 +60,7 @@ def pixel2Geographic(jsonFileLocation, headerFileLocation, cameraOption):
             y_gantry_pos = float(master["gantry_system_variable_metadata"]["Position y [m]"])
 
         else: # We notice that there are cases that no position data available
-            return 0, 0, [0]*4 , ""
+            return [0], [0], [0]*4 , ""
 
         x_camera_pos = 1.9 # From https://github.com/terraref/reference-data/issues/32
         y_camera_pos = 0.855

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -536,9 +536,6 @@ def translate_time(gantry_system_time, frameTimeString=None):
         timeUnpack = datetime.strptime(gantry_system_time, "%m/%d/%Y %H:%M:%S").timetuple()
     elif time_pattern[0].match(gantry_system_time):
         timeUnpack = datetime.strptime(gantry_system_time, "%Y-%m-%d").timetuple()
-    else:
-        print "uncatched pattern", gantry_system_time
-        return 16000
 
     timeSplit  = date(year=timeUnpack.tm_year, month=timeUnpack.tm_mon,
                       day=timeUnpack.tm_mday) - _unix_basetime #time period to the UNIX basetime

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -464,6 +464,11 @@ def _generate_attr(string):
     long_name = ""
     if "current setting" in string:
         long_name = string.split(' ')[-1]
+        return long_name,\
+               {
+                   "long_name": _reformat_string(string) 
+               }
+               
     elif "speed" in string and "current setting" not in string:
         long_name = "".join(('Gantry Speed in ', string[6].upper(), ' Direction'))
         return _reformat_string(string),\

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -145,6 +145,7 @@ class DataContainer(object):
         for key, data in self.__dict__.items():
             tempGroup = netCDFHandler.createGroup(key) if not flatten else netCDFHandler
             for subkey, subdata in data.items():
+                print subkey
                 if not _IS_DIGIT(subdata): #Case for letter variables
 
                     ##### For date variables #####

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -152,6 +152,7 @@ class DataContainer(object):
                         assert subdata != "todo", '"todo" is not a legal value for the keys'
 
                         tempVariable = tempGroup.createVariable(_reformat_string(subkey), 'f8')
+                        print "subkey is", subkey
                         tempVariable[...] = translate_time(subdata)
                         setattr(tempVariable, "units",     "days since 1970-01-01 00:00:00")
                         setattr(tempVariable, "calender", "gregorian")

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -532,11 +532,12 @@ def translate_time(gantry_system_time, frameTimeString=None):
     time_pattern      = re.compile(r'(\d{4})-(\d{2})-(\d{2})'),\
                         re.compile(r'(\d{2})/(\d{2})/(\d{4})\s(\d{2}):(\d{2}):(\d{2})'),\
                         re.compile(r'(\d{2}):(\d{2}):(\d{2})')
-
+    print "the gantry time is", gantry_system_time
     if frameTimeString:
         hourUnpack = datetime.strptime(frameTimeString, "%H:%M:%S").timetuple()
     
     if time_pattern[1].match(gantry_system_time):
+        print "it matches!!!!!!!!!!"
         timeUnpack = datetime.strptime(gantry_system_time, "%m/%d/%Y %H:%M:%S").timetuple()
     elif time_pattern[0].match(gantry_system_time):
         timeUnpack = datetime.strptime(gantry_system_time, "%Y-%m-%d").timetuple()

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -160,11 +160,7 @@ class DataContainer(object):
                     setattr(tempGroup, _reformat_string(subkey), subdata)
 
                 else: #Case for digits variables
-                    if "timestamp" in subkey:
-                        gantry_system_time = subdata
-                    elif "time" in subkey:
-                        gantry_system_time = subdata
-                    elif "Time" in subkey:
+                    if "timestamp" in subkey or "time" in subkey or "Time" in subkey:
                         gantry_system_time = subdata
 
                     setattr(tempGroup, _reformat_string(subkey), subdata)
@@ -533,7 +529,6 @@ def translate_time(gantry_system_time, frameTimeString=None):
     time_pattern      = re.compile(r'(\d{4})-(\d{2})-(\d{2})'),\
                         re.compile(r'(\d{2})/(\d{2})/(\d{4})\s(\d{2}):(\d{2}):(\d{2})'),\
                         re.compile(r'(\d{2}):(\d{2}):(\d{2})')
-    print "the gantry time is", type(gantry_system_time)
     if frameTimeString:
         hourUnpack = datetime.strptime(frameTimeString, "%H:%M:%S").timetuple()
     

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -160,12 +160,12 @@ class DataContainer(object):
                     setattr(tempGroup, _reformat_string(subkey), subdata)
 
                 else: #Case for digits variables
-                    if "timestamp" in data:
-                        gantry_system_time = data["timestamp"]
-                    elif "time" in data:
-                        gantry_system_time = data["time"]
-                    elif "Time" in data:
-                        gantry_system_time = data["Time"]
+                    if "timestamp" in subkey:
+                        gantry_system_time = subdata
+                    elif "time" in subkey:
+                        gantry_system_time = subdata
+                    elif "Time" in subkey:
+                        gantry_system_time = subdata
 
                     setattr(tempGroup, _reformat_string(subkey), subdata)
 

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -158,9 +158,13 @@ class DataContainer(object):
                     setattr(tempGroup, _reformat_string(subkey), subdata)
 
                 else: #Case for digits variables
-                    if "time" in data or "Time" in data or "timestamp" in data:
-                        print "catched:", data["time"]
+                    if "time" in data: 
                         gantry_system_time = data["time"]
+                    elif "Time" in data:
+                        gantry_system_time = data["Time"]
+                    elif "timestamp" in data:
+                        gantry_system_time = data["timestamp"]
+
                     setattr(tempGroup, _reformat_string(subkey), subdata)
 
                     short_name, attributes = _generate_attr(subkey)

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -161,9 +161,10 @@ class DataContainer(object):
 
                     setattr(tempGroup, _reformat_string(subkey), subdata)
 
-                else: #Case for digits variables
                     if "timestamp" in subkey or "time" in subkey or "Time" in subkey:
                         gantry_system_time = subdata
+
+                else: #Case for digits variables
 
                     setattr(tempGroup, _reformat_string(subkey), subdata)
 

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -537,7 +537,7 @@ def translate_time(gantry_system_time, frameTimeString=None):
     elif time_pattern[0].match(gantry_system_time):
         timeUnpack = datetime.strptime(gantry_system_time, "%Y-%m-%d").timetuple()
     else:
-        print "uncatched pattern", time_pattern
+        print "uncatched pattern", gantry_system_time
         return 0
 
     timeSplit  = date(year=timeUnpack.tm_year, month=timeUnpack.tm_mon,

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -186,7 +186,6 @@ class DataContainer(object):
         write_header_file(inputFilePath, netCDFHandler, flatten, _debug)
 
         ##### Write the data from frameIndex files to netCDF #####
-        print "gantry time is", gantry_system_time
         tempFrameTime = frame_index_parser(''.join((inputFilePath.strip("raw"), "frameIndex.txt")), gantry_system_time)
         netCDFHandler.createDimension("time", len(tempFrameTime))
 

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -542,6 +542,8 @@ def translate_time(gantry_system_time, frameTimeString=None):
         timeUnpack = datetime.strptime(gantry_system_time, "%m/%d/%Y %H:%M:%S").timetuple()
     elif time_pattern[0].match(gantry_system_time):
         timeUnpack = datetime.strptime(gantry_system_time, "%Y-%m-%d").timetuple()
+    else:
+        return 0
 
     timeSplit  = date(year=timeUnpack.tm_year, month=timeUnpack.tm_mon,
                       day=timeUnpack.tm_mday) - _unix_basetime #time period to the UNIX basetime

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -152,6 +152,7 @@ class DataContainer(object):
                         assert subdata != "todo", '"todo" is not a legal value for the keys'
 
                         tempVariable = tempGroup.createVariable(_reformat_string(subkey), 'f8')
+                        print "subkey is", subkey
                         tempVariable[...] = translate_time(subdata)
                         setattr(tempVariable, "units",     "days since 1970-01-01 00:00:00")
                         setattr(tempVariable, "calender", "gregorian")
@@ -193,7 +194,6 @@ class DataContainer(object):
         assert len(tempFrameTime), "ERROR: Failed to collect frame time information from " + ''.join((inputFilePath.strip("raw"), "frameIndex.txt")) + ". Please check the file."
        
         frameTime      = netCDFHandler.createVariable("frametime", "f8", ("time",))
-        print tempFrameTime[0]
         frameTime[...] = tempFrameTime
         setattr(frameTime, "units",    "days since 1970-01-01 00:00:00")
         setattr(frameTime, "calender", "gregorian")
@@ -536,6 +536,9 @@ def translate_time(gantry_system_time, frameTimeString=None):
         timeUnpack = datetime.strptime(gantry_system_time, "%m/%d/%Y %H:%M:%S").timetuple()
     elif time_pattern[0].match(gantry_system_time):
         timeUnpack = datetime.strptime(gantry_system_time, "%Y-%m-%d").timetuple()
+    else:
+        print "uncatched pattern", time_pattern
+        return 0
 
     timeSplit  = date(year=timeUnpack.tm_year, month=timeUnpack.tm_mon,
                       day=timeUnpack.tm_mday) - _unix_basetime #time period to the UNIX basetime

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -533,12 +533,9 @@ def translate_time(gantry_system_time, frameTimeString=None):
         hourUnpack = datetime.strptime(frameTimeString, "%H:%M:%S").timetuple()
     
     if time_pattern[1].match(gantry_system_time):
-        print "it matches!!!!!!!!!!"
         timeUnpack = datetime.strptime(gantry_system_time, "%m/%d/%Y %H:%M:%S").timetuple()
     elif time_pattern[0].match(gantry_system_time):
         timeUnpack = datetime.strptime(gantry_system_time, "%Y-%m-%d").timetuple()
-    else:
-        return 0
 
     timeSplit  = date(year=timeUnpack.tm_year, month=timeUnpack.tm_mon,
                       day=timeUnpack.tm_mday) - _unix_basetime #time period to the UNIX basetime

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -160,8 +160,11 @@ class DataContainer(object):
 
                 else: #Case for digits variables
                     if "timestamp" in data:
-                        print data["timestamp"]
                         gantry_system_time = data["timestamp"]
+                    elif "time" in data:
+                        gantry_system_time = data["time"]
+                    elif "Time" in data:
+                        gantry_system_time = data["Time"]
 
                     setattr(tempGroup, _reformat_string(subkey), subdata)
 

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -159,6 +159,7 @@ class DataContainer(object):
 
                 else: #Case for digits variables
                     if "time" in data or "Time" in data or "timestamp" in data:
+                        print "catched:", data["time"]
                         gantry_system_time = data["time"]
                     setattr(tempGroup, _reformat_string(subkey), subdata)
 
@@ -468,7 +469,7 @@ def _generate_attr(string):
                {
                    "long_name": _reformat_string(string) 
                }
-               
+
     elif "speed" in string and "current setting" not in string:
         long_name = "".join(('Gantry Speed in ', string[6].upper(), ' Direction'))
         return _reformat_string(string),\

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -159,11 +159,7 @@ class DataContainer(object):
                     setattr(tempGroup, _reformat_string(subkey), subdata)
 
                 else: #Case for digits variables
-                    if "time" in data: 
-                        gantry_system_time = data["time"]
-                    elif "Time" in data:
-                        gantry_system_time = data["Time"]
-                    elif "timestamp" in data:
+                    if "timestamp" in data
                         gantry_system_time = data["timestamp"]
 
                     setattr(tempGroup, _reformat_string(subkey), subdata)

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -138,7 +138,8 @@ class DataContainer(object):
         delattr(self, "header_info")
 
         #### default camera is SWIR, but will see based on the number of wavelengths
-        camera_opt = "SWIR"
+        camera_opt         = "SWIR"
+        gantry_system_time = ""
 
         ##### Write the data from metadata to netCDF #####
         for key, data in self.__dict__.items():

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -188,6 +188,7 @@ class DataContainer(object):
         write_header_file(inputFilePath, netCDFHandler, flatten, _debug)
 
         ##### Write the data from frameIndex files to netCDF #####
+        print "gantry time is", gantry_system_time
         tempFrameTime = frame_index_parser(''.join((inputFilePath.strip("raw"), "frameIndex.txt")), gantry_system_time)
         netCDFHandler.createDimension("time", len(tempFrameTime))
 

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -538,7 +538,7 @@ def translate_time(gantry_system_time, frameTimeString=None):
         timeUnpack = datetime.strptime(gantry_system_time, "%Y-%m-%d").timetuple()
     else:
         print "uncatched pattern", gantry_system_time
-        return 0
+        return 16000
 
     timeSplit  = date(year=timeUnpack.tm_year, month=timeUnpack.tm_mon,
                       day=timeUnpack.tm_mday) - _unix_basetime #time period to the UNIX basetime

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -152,7 +152,6 @@ class DataContainer(object):
                         assert subdata != "todo", '"todo" is not a legal value for the keys'
 
                         tempVariable = tempGroup.createVariable(_reformat_string(subkey), 'f8')
-                        print "subkey is", subkey
                         tempVariable[...] = translate_time(subdata)
                         setattr(tempVariable, "units",     "days since 1970-01-01 00:00:00")
                         setattr(tempVariable, "calender", "gregorian")
@@ -194,6 +193,7 @@ class DataContainer(object):
         assert len(tempFrameTime), "ERROR: Failed to collect frame time information from " + ''.join((inputFilePath.strip("raw"), "frameIndex.txt")) + ". Please check the file."
        
         frameTime      = netCDFHandler.createVariable("frametime", "f8", ("time",))
+        print tempFrameTime[0]
         frameTime[...] = tempFrameTime
         setattr(frameTime, "units",    "days since 1970-01-01 00:00:00")
         setattr(frameTime, "calender", "gregorian")

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -139,13 +139,11 @@ class DataContainer(object):
 
         #### default camera is SWIR, but will see based on the number of wavelengths
         camera_opt         = "SWIR"
-        gantry_system_time = ""
 
         ##### Write the data from metadata to netCDF #####
         for key, data in self.__dict__.items():
             tempGroup = netCDFHandler.createGroup(key) if not flatten else netCDFHandler
             for subkey, subdata in data.items():
-                print subkey
                 if not _IS_DIGIT(subdata): #Case for letter variables
 
                     ##### For date variables #####
@@ -153,9 +151,7 @@ class DataContainer(object):
                         assert subdata != "todo", '"todo" is not a legal value for the keys'
 
                         tempVariable = tempGroup.createVariable(_reformat_string(subkey), 'f8')
-                        print "subkey is", subkey
                         tempVariable[...] = translate_time(subdata)
-                        print "pass"
                         setattr(tempVariable, "units",     "days since 1970-01-01 00:00:00")
                         setattr(tempVariable, "calender", "gregorian")
 

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -158,10 +158,8 @@ class DataContainer(object):
                     setattr(tempGroup, _reformat_string(subkey), subdata)
 
                 else: #Case for digits variables
-                    if "time" in data:
-                        yearMonthDate = data["time"]
-                    elif "Time" in data:
-                        yearMonthDate = data["Time"]
+                    if "time" in data or "Time" in data or "timestamp" in data:
+                        gantry_system_time = data["time"]
                     setattr(tempGroup, _reformat_string(subkey), subdata)
 
                     short_name, attributes = _generate_attr(subkey)
@@ -186,7 +184,7 @@ class DataContainer(object):
         write_header_file(inputFilePath, netCDFHandler, flatten, _debug)
 
         ##### Write the data from frameIndex files to netCDF #####
-        tempFrameTime = frame_index_parser(''.join((inputFilePath.strip("raw"), "frameIndex.txt")), yearMonthDate)
+        tempFrameTime = frame_index_parser(''.join((inputFilePath.strip("raw"), "frameIndex.txt")), gantry_system_time)
         netCDFHandler.createDimension("time", len(tempFrameTime))
 
         # Check if the frame time information is correctly collected
@@ -468,37 +466,36 @@ def _generate_attr(string):
         long_name = string.split(' ')[-1]
     elif "speed" in string and "current setting" not in string:
         long_name = "".join(('Gantry Speed in ', string[6].upper(), ' Direction'))
+        return _reformat_string(string),\
+               {
+                   "units"    : _UNIT_DICTIONARY[string[string.find('[') + 1:string.find(']')]],
+                   "long_name": long_name
+               }
+
     elif "Velocity" in string or "velocity" in string:
         long_name = "".join(('Gantry velocity in ', string[9].upper(), ' Direction'))
+        return _reformat_string(string),\
+               {
+                   "units"    : _UNIT_DICTIONARY[string[string.find('[') + 1:string.find(']')]],
+                   "long_name": long_name
+               }
+
     elif "Position" in string or "position" in string:
         long_name = "".join(('Position in ', string[9].upper(), ' Direction'))
+        return _reformat_string(string),\
+               {
+                   "units"    : _UNIT_DICTIONARY[string[string.find('[') + 1:string.find(']')]],
+                   "long_name": long_name
+               }
+
     else:
         long_name = _reformat_string(string)
-
-    if 'Position' in string or 'position' in string:
-        return _reformat_string(string),\
-               {
-                   "units"    : _UNIT_DICTIONARY[string[string.find('[') + 1:string.find(']')]],
-                   "long_name": long_name
-               }
-    elif 'Velocity' in string or 'velocity' in string:
-        return _reformat_string(string),\
-               {
-                   "units"    : _UNIT_DICTIONARY[string[string.find('[') + 1:string.find(']')]],
-                   "long_name": long_name
-               }
-    elif 'speed' in string and "current setting" not in string:
-        return _reformat_string(string),\
-               {
-                   "units"    : _UNIT_DICTIONARY[string[string.find('[') + 1:string.find(']')]],
-                   "long_name": long_name
-               }
-    else:
         return long_name,\
                {
                    "long_name": _reformat_string(string) 
                }
-               
+        
+              
 
 def _filter_the_headings(target):
     '''
@@ -518,7 +515,7 @@ def jsonHandler(jsonFile, _debug=True):
             jsonCheck(fileHandler)
         return json.loads(fileHandler.read(), object_hook=_filter_the_headings)
 
-def translate_time(yearMonthDate, frameTimeString=None):
+def translate_time(gantry_system_time, frameTimeString=None):
     hourUnpack, timeUnpack = None, None
     _unix_basetime    = date(year=1970, month=1, day=1)
     time_pattern      = re.compile(r'(\d{4})-(\d{2})-(\d{2})'),\
@@ -528,10 +525,10 @@ def translate_time(yearMonthDate, frameTimeString=None):
     if frameTimeString:
         hourUnpack = datetime.strptime(frameTimeString, "%H:%M:%S").timetuple()
     
-    if time_pattern[1].match(yearMonthDate):
-        timeUnpack = datetime.strptime(yearMonthDate, "%m/%d/%Y %H:%M:%S").timetuple()
-    elif time_pattern[0].match(yearMonthDate):
-        timeUnpack = datetime.strptime(yearMonthDate, "%Y-%m-%d").timetuple()
+    if time_pattern[1].match(gantry_system_time):
+        timeUnpack = datetime.strptime(gantry_system_time, "%m/%d/%Y %H:%M:%S").timetuple()
+    elif time_pattern[0].match(gantry_system_time):
+        timeUnpack = datetime.strptime(gantry_system_time, "%Y-%m-%d").timetuple()
 
     timeSplit  = date(year=timeUnpack.tm_year, month=timeUnpack.tm_mon,
                       day=timeUnpack.tm_mday) - _unix_basetime #time period to the UNIX basetime
@@ -541,12 +538,12 @@ def translate_time(yearMonthDate, frameTimeString=None):
     else:
         return timeSplit.total_seconds() / (3600.0 * 24.0)
 
-def frame_index_parser(fileName, yearMonthDate):
+def frame_index_parser(fileName, gantry_system_time):
     '''
     translate all the time in *frameIndex.txt
     '''
     with open(fileName) as fileHandler:
-        return [translate_time(yearMonthDate, dataMembers.split()[1]) for dataMembers in fileHandler.readlines()[1:]]
+        return [translate_time(gantry_system_time, dataMembers.split()[1]) for dataMembers in fileHandler.readlines()[1:]]
 
 
 def file_dependency_check(filePath):

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -533,7 +533,7 @@ def translate_time(gantry_system_time, frameTimeString=None):
     time_pattern      = re.compile(r'(\d{4})-(\d{2})-(\d{2})'),\
                         re.compile(r'(\d{2})/(\d{2})/(\d{4})\s(\d{2}):(\d{2}):(\d{2})'),\
                         re.compile(r'(\d{2}):(\d{2}):(\d{2})')
-    print "the gantry time is", gantry_system_time
+    print "the gantry time is", type(gantry_system_time)
     if frameTimeString:
         hourUnpack = datetime.strptime(frameTimeString, "%H:%M:%S").timetuple()
     

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -160,6 +160,7 @@ class DataContainer(object):
 
                 else: #Case for digits variables
                     if "timestamp" in data:
+                        print data["timestamp"]
                         gantry_system_time = data["timestamp"]
 
                     setattr(tempGroup, _reformat_string(subkey), subdata)

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -154,6 +154,7 @@ class DataContainer(object):
                         tempVariable = tempGroup.createVariable(_reformat_string(subkey), 'f8')
                         print "subkey is", subkey
                         tempVariable[...] = translate_time(subdata)
+                        print "pass"
                         setattr(tempVariable, "units",     "days since 1970-01-01 00:00:00")
                         setattr(tempVariable, "calender", "gregorian")
 

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -159,7 +159,7 @@ class DataContainer(object):
                     setattr(tempGroup, _reformat_string(subkey), subdata)
 
                 else: #Case for digits variables
-                    if "timestamp" in data
+                    if "timestamp" in data:
                         gantry_system_time = data["timestamp"]
 
                     setattr(tempGroup, _reformat_string(subkey), subdata)


### PR DESCRIPTION
This update includes the following fixes:

**On [hyperspectral_metadata.py](../blob/master/hyperspectral/hyperspectral_calculation.py)**

- Add more keywords to recognize the gantry time in the metadata. Now "timestamp", "time" and "Time" are all keywords. This change is based on the report from @max-zilla in the [computing-pipeline issue #230](https://github.com/terraref/computing-pipeline/issues/230). Max spotted it in the file from 12/05.

- Refactor part of the codes (to remove redundant) 

**On [hyperspectral_calculation.py](../blob/master/hyperspectral/hyperspectral_calculation.py)**

- From the same [issue](https://github.com/terraref/computing-pipeline/issues/230) above I notice that some of the metadata file DOES NOT have gantry position and speed information, which makes the pixels untraceable. In this case, the calculation module will be disabled and returns all zeros for longitude, latitude and bounding box. Google Map locating is also not available.

**Testing**
- The updates had already been tested with VNIR data from 10-06 and 12-05.

**Bottom Line**
Probably we need some standards for the metadata files. Too many customized cases start to weaken the maintainability of the program 