### PR TITLE
Add _FillValue and Latitude, Longitude values

### DIFF
--- a/hyperspectral/hyperspectral_calculation.py
+++ b/hyperspectral/hyperspectral_calculation.py
@@ -60,7 +60,10 @@ def pixel2Geographic(jsonFileLocation, headerFileLocation, cameraOption):
             y_gantry_pos = float(master["gantry_system_variable_metadata"]["Position y [m]"])
 
         else: # We notice that there are cases that no position data available
-            return [0], [0], ["0, 0"]*4 , ""
+            return {"x_coordinates": None,
+                    "y_coordinates": None,
+                    "bounding_box" : None,
+                    "Google_Map"   : None}
 
         x_camera_pos = 1.9 # From https://github.com/terraref/reference-data/issues/32
         y_camera_pos = 0.855
@@ -97,10 +100,13 @@ def pixel2Geographic(jsonFileLocation, headerFileLocation, cameraOption):
         NE = x_final_result[-1] * LONGITUDE_TO_METER + REFERENCE_POINT[0], y_final_result[0]  * LATITUDE_TO_METER + REFERENCE_POINT[1]
         NW = x_final_result[0] * LONGITUDE_TO_METER + REFERENCE_POINT[0] , y_final_result[0]  * LATITUDE_TO_METER + REFERENCE_POINT[1]
 
-        bounding_box = [str(SE).strip("()"), str(SW).strip("()"), str(NE).strip("()"), str(NW).strip("()")]
+        bounding_box = (str(SE).strip("()"), str(SW).strip("()"), str(NE).strip("()"), str(NW).strip("()"))
         bounding_box_mapview = GOOGLE_MAP_TEMPLATE.format(pointA=bounding_box[0],
                                                           pointB=bounding_box[1],
                                                           pointC=bounding_box[2],
                                                           pointD=bounding_box[3])
 
-        return x_final_result, y_final_result, bounding_box, bounding_box_mapview
+        return {"x_coordinates": x_final_result,
+                "y_coordinates": y_final_result,
+                "bounding_box" : bounding_box,
+                "Google_Map"   : bounding_box_mapview}

--- a/hyperspectral/hyperspectral_calculation.py
+++ b/hyperspectral/hyperspectral_calculation.py
@@ -109,7 +109,7 @@ def pixel2Geographic(jsonFileLocation, headerFileLocation, cameraOption):
                                                           pointD=bounding_box[3])
 
         lat_final_result = np.array([x * LATITUDE_TO_METER for x in x_final_result])  + REFERENCE_POINT[0]
-        lon_final_result = np.array([y * LONGITUDE_TO_METER for y in y_final_result]) - REFERENCE_POINT[1]
+        lon_final_result = np.array([-y * LONGITUDE_TO_METER for y in y_final_result]) + REFERENCE_POINT[1]
 
         return {"x_coordinates": x_final_result,
                 "y_coordinates": y_final_result,

--- a/hyperspectral/hyperspectral_calculation.py
+++ b/hyperspectral/hyperspectral_calculation.py
@@ -62,6 +62,8 @@ def pixel2Geographic(jsonFileLocation, headerFileLocation, cameraOption):
         else: # We notice that there are cases that no position data available
             return {"x_coordinates": None,
                     "y_coordinates": None,
+                    "latitudes"    : None,
+                    "longitudes"   : None,
                     "bounding_box" : None,
                     "Google_Map"   : None}
 
@@ -106,7 +108,12 @@ def pixel2Geographic(jsonFileLocation, headerFileLocation, cameraOption):
                                                           pointC=bounding_box[2],
                                                           pointD=bounding_box[3])
 
+        lat_final_result = np.array([x * LATITUDE_TO_METER for x in x_final_result])  + REFERENCE_POINT[0]
+        lon_final_result = np.array([y * LONGITUDE_TO_METER for y in y_final_result]) - REFERENCE_POINT[1]
+
         return {"x_coordinates": x_final_result,
                 "y_coordinates": y_final_result,
+                "latitudes"    : lat_final_result,
+                "longitudes"   : lon_final_result,
                 "bounding_box" : bounding_box,
                 "Google_Map"   : bounding_box_mapview}

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -272,6 +272,8 @@ class DataContainer(object):
             lonNe = netCDFHandler.createVariable("lon_img_ne", "f8", fill_value=1e36)
             latNw = netCDFHandler.createVariable("lat_img_nw", "f8", fill_value=1e36)
             lonNw = netCDFHandler.createVariable("lon_img_nw", "f8", fill_value=1e36)
+            lats  = netCDFHandler.createVariable("lats", "f8", fill_value=1e36)
+            lons  = netCDFHandler.createVariable("lons", "f8", fill_value=1e36)
 
             netCDFHandler.close()
             return

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -383,13 +383,13 @@ class DataContainer(object):
 
         lats = netCDFHandler.createVariable("latitude", "f8", ("x",))
         lats[...] = geo_data["latitudes"]
-        setattr(netCDFHandler.variables["latitude"], "units", "degree_north")
+        setattr(netCDFHandler.variables["latitude"], "units", "degrees")
         setattr(netCDFHandler.variables["latitude"], "long_name", "The precise latitude value for each pixel in the picture")
         setattr(netCDFHandler.variables["latitude"], "comment", "increasing toward the North direction, always positive")
 
         lons = netCDFHandler.createVariable("longitude", "f8", ("y",))
         lons[...] = geo_data["longitudes"]
-        setattr(netCDFHandler.variables["longitude"], "units", "degree_east")
+        setattr(netCDFHandler.variables["longitude"], "units", "degrees")
         setattr(netCDFHandler.variables["longitude"], "long_name", "The precise longitude value for each pixel in the picture")
         setattr(netCDFHandler.variables["longitude"], "comment", "decreasing toward the West direction, always negative")
 

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -381,17 +381,17 @@ class DataContainer(object):
         setattr(netCDFHandler.variables["y_img_nw"], "units", "meters")
         setattr(netCDFHandler.variables["y_img_nw"], "long_name", "Northwest corner of image, west distance to reference point")
 
-        lats = netCDFHandler.createVariable("lats", "f8", ("x",))
+        lats = netCDFHandler.createVariable("latitude", "f8", ("x",))
         lats[...] = geo_data["latitudes"]
-        setattr(netCDFHandler.variables["lats"], "units", "degrees")
-        setattr(netCDFHandler.variables["lats"], "long_name", "The precise latitude value for each pixel in the picture")
-        setattr(netCDFHandler.variables["lats"], "comment", "increasing toward the North direction, always positive")
+        setattr(netCDFHandler.variables["latitude"], "units", "degree")
+        setattr(netCDFHandler.variables["latitude"], "long_name", "The precise latitude value for each pixel in the picture")
+        setattr(netCDFHandler.variables["latitude"], "comment", "increasing toward the North direction, always positive")
 
-        lons = netCDFHandler.createVariable("lons", "f8", ("y",))
+        lons = netCDFHandler.createVariable("longitude", "f8", ("y",))
         lons[...] = geo_data["longitudes"]
-        setattr(netCDFHandler.variables["lons"], "units", "degrees")
-        setattr(netCDFHandler.variables["lons"], "long_name", "The precise longitude value for each pixel in the picture")
-        setattr(netCDFHandler.variables["lats"], "comment", "decreasing toward the West direction, always negative")
+        setattr(netCDFHandler.variables["longitude"], "units", "degree")
+        setattr(netCDFHandler.variables["longitude"], "long_name", "The precise longitude value for each pixel in the picture")
+        setattr(netCDFHandler.variables["longitude"], "comment", "decreasing toward the West direction, always negative")
 
 
         if format == "NETCDF3_CLASSIC":

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -261,7 +261,7 @@ class DataContainer(object):
         netCDFHandler.history = ''.join((_TIMESTAMP(), ': python ', commandLine))
 
         ### If failed to get the georeference values, pre_fill all the values with _FillValue=1e36 and close. ###
-        if not geo_data["x_coordinates"]:
+        if geo_data["x_coordinates"] is None:
 
             x = netCDFHandler.createVariable("x", "f8", fill_value=1e36)
             y = netCDFHandler.createVariable("y", "f8", fill_value=1e36)

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -262,7 +262,6 @@ class DataContainer(object):
 
         ### If failed to get the georeference values, pre_fill all the values with _FillValue=1e36 and close. ###
         if geo_data["x_coordinates"] is None:
-
             x = netCDFHandler.createVariable("x", "f8", fill_value=1e36)
             y = netCDFHandler.createVariable("y", "f8", fill_value=1e36)
             latSe = netCDFHandler.createVariable("lat_img_se", "f8", fill_value=1e36)
@@ -379,7 +378,20 @@ class DataContainer(object):
         yNw[...] = float(y[0])
         setattr(netCDFHandler.variables["y_img_nw"], "units", "meters")
         setattr(netCDFHandler.variables["y_img_nw"], "long_name", "Northwest corner of image, west distance to reference point")
-        
+
+        lats = netCDFHandler.createVariable("lats", "f8", ("x",))
+        lats[...] = geo_data["latitudes"]
+        setattr(netCDFHandler.variables["lats"], "units", "degrees")
+        setattr(netCDFHandler.variables["lats"], "long_name", "The precise latitude value for each pixel in the picture")
+        setattr(netCDFHandler.variables["lats"], "comment", "increasing toward the North direction, always positive")
+
+        lons = netCDFHandler.createVariable("lons", "f8", ("y",))
+        lats[...] = geo_data["longitudes"]
+        setattr(netCDFHandler.variables["lons"], "units", "degrees")
+        setattr(netCDFHandler.variables["lons"], "long_name", "The precise longitude value for each pixel in the picture")
+        setattr(netCDFHandler.variables["lats"], "comment", "decreasing toward the West direction, always negative")
+
+
         if format == "NETCDF3_CLASSIC":
             netCDFHandler.createDimension("length of Google Map String", len(geo_data["Google_Map"]))
             googleMapView = netCDFHandler.createVariable("Google_Map_View", "S1", ("length of Google Map String",))

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -272,8 +272,8 @@ class DataContainer(object):
             lonNe = netCDFHandler.createVariable("lon_img_ne", "f8", fill_value=NCATTRS["_FillValue"])
             latNw = netCDFHandler.createVariable("lat_img_nw", "f8", fill_value=NCATTRS["_FillValue"])
             lonNw = netCDFHandler.createVariable("lon_img_nw", "f8", fill_value=NCATTRS["_FillValue"])
-            lats  = netCDFHandler.createVariable("lats", "f8", fill_value=NCATTRS["_FillValue"])
-            lons  = netCDFHandler.createVariable("lons", "f8", fill_value=NCATTRS["_FillValue"])
+            lats  = netCDFHandler.createVariable("latitude", "f8", fill_value=NCATTRS["_FillValue"])
+            lons  = netCDFHandler.createVariable("longitude", "f8", fill_value=NCATTRS["_FillValue"])
 
             netCDFHandler.close()
             return

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -216,13 +216,13 @@ class DataContainer(object):
 
         lat_pt_var = netCDFHandler.createVariable("lat_reference_point", "f8")
         lat_pt_var[...] = lat_pt
-        setattr(netCDFHandler.variables["lat_reference_point"], "units", "degrees")
+        setattr(netCDFHandler.variables["lat_reference_point"], "units", "degrees_north")
         setattr(netCDFHandler.variables["lat_reference_point"], "long_name", "Latitude of the master reference point at southeast corner of field")
         setattr(netCDFHandler.variables["lat_reference_point"], "provenance", "https://github.com/terraref/reference-data/issues/32 by Dr. David LeBauer")
 
         lon_pt_var = netCDFHandler.createVariable("lon_reference_point", "f8")
         lon_pt_var[...] = lon_pt
-        setattr(netCDFHandler.variables["lon_reference_point"], "units", "degrees")
+        setattr(netCDFHandler.variables["lon_reference_point"], "units", "degrees_east")
         setattr(netCDFHandler.variables["lon_reference_point"], "long_name", "Longitude of the master reference point at southeast corner of field")
         setattr(netCDFHandler.variables["lon_reference_point"], "provenance", "https://github.com/terraref/reference-data/issues/32 by Dr. David LeBauer")
 
@@ -301,43 +301,43 @@ class DataContainer(object):
 
         latSe = netCDFHandler.createVariable("lat_img_se", "f8")
         latSe[...] = float(lat_se)
-        setattr(netCDFHandler.variables["lat_img_se"], "units", "degrees")
+        setattr(netCDFHandler.variables["lat_img_se"], "units", "degrees_north")
         setattr(netCDFHandler.variables["lat_img_se"], "long_name", "Latitude of southeast corner of image")
 
         # have a "x_y_img_se" in meters, double
         lonSe = netCDFHandler.createVariable("lon_img_se", "f8")
         lonSe[...] = float(lon_se)
-        setattr(netCDFHandler.variables["lon_img_se"], "units", "degrees")
+        setattr(netCDFHandler.variables["lon_img_se"], "units", "degrees_east")
         setattr(netCDFHandler.variables["lon_img_se"], "long_name", "Longitude of southeast corner of image")
 
         latSw = netCDFHandler.createVariable("lat_img_sw", "f8")
         latSw[...] = float(lat_sw)
-        setattr(netCDFHandler.variables["lat_img_sw"], "units", "degrees")
+        setattr(netCDFHandler.variables["lat_img_sw"], "units", "degrees_north")
         setattr(netCDFHandler.variables["lat_img_sw"], "long_name", "Latitude of southwest corner of image")
 
         lonSw = netCDFHandler.createVariable("lon_img_sw", "f8")
         lonSw[...] = float(lon_sw)
-        setattr(netCDFHandler.variables["lon_img_sw"], "units", "degrees")
+        setattr(netCDFHandler.variables["lon_img_sw"], "units", "degrees_east")
         setattr(netCDFHandler.variables["lon_img_sw"], "long_name", "Longitude of southwest corner of image")
 
         latNe = netCDFHandler.createVariable("lat_img_ne", "f8")
         latNe[...] = float(lat_ne)
-        setattr(netCDFHandler.variables["lat_img_ne"], "units", "degrees")
+        setattr(netCDFHandler.variables["lat_img_ne"], "units", "degrees_north")
         setattr(netCDFHandler.variables["lat_img_ne"], "long_name", "Latitude of northeast corner of image")
 
         lonNe = netCDFHandler.createVariable("lon_img_ne", "f8")
         lonNe[...] = float(lon_ne)
-        setattr(netCDFHandler.variables["lon_img_ne"], "units", "degrees")
+        setattr(netCDFHandler.variables["lon_img_ne"], "units", "degrees_east")
         setattr(netCDFHandler.variables["lon_img_ne"], "long_name", "Longitude of northeast corner of image")
 
         latNw = netCDFHandler.createVariable("lat_img_nw", "f8")
         latNw[...] = float(lat_nw)
-        setattr(netCDFHandler.variables["lat_img_nw"], "units", "degrees")
+        setattr(netCDFHandler.variables["lat_img_nw"], "units", "degrees_north")
         setattr(netCDFHandler.variables["lat_img_nw"], "long_name", "Latitude of northwest corner of image")
 
         lonNw = netCDFHandler.createVariable("lon_img_nw", "f8")
         lonNw[...] = float(lon_nw)
-        setattr(netCDFHandler.variables["lon_img_nw"], "units", "degrees")
+        setattr(netCDFHandler.variables["lon_img_nw"], "units", "degrees_east")
         setattr(netCDFHandler.variables["lon_img_nw"], "long_name", "Longitude of northwest corner of image")
 
         xSe = netCDFHandler.createVariable("x_img_se", "f8")
@@ -383,13 +383,13 @@ class DataContainer(object):
 
         lats = netCDFHandler.createVariable("latitude", "f8", ("x",))
         lats[...] = geo_data["latitudes"]
-        setattr(netCDFHandler.variables["latitude"], "units", "degrees")
+        setattr(netCDFHandler.variables["latitude"], "units", "degree_north")
         setattr(netCDFHandler.variables["latitude"], "long_name", "The precise latitude value for each pixel in the picture")
         setattr(netCDFHandler.variables["latitude"], "comment", "increasing toward the North direction, always positive")
 
         lons = netCDFHandler.createVariable("longitude", "f8", ("y",))
         lons[...] = geo_data["longitudes"]
-        setattr(netCDFHandler.variables["longitude"], "units", "degrees")
+        setattr(netCDFHandler.variables["longitude"], "units", "degree_east")
         setattr(netCDFHandler.variables["longitude"], "long_name", "The precise longitude value for each pixel in the picture")
         setattr(netCDFHandler.variables["longitude"], "comment", "decreasing toward the West direction, always negative")
 

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -216,13 +216,13 @@ class DataContainer(object):
 
         lat_pt_var = netCDFHandler.createVariable("lat_reference_point", "f8")
         lat_pt_var[...] = lat_pt
-        setattr(netCDFHandler.variables["lat_reference_point"], "units", "degrees_north")
+        setattr(netCDFHandler.variables["lat_reference_point"], "units", "degrees")
         setattr(netCDFHandler.variables["lat_reference_point"], "long_name", "Latitude of the master reference point at southeast corner of field")
         setattr(netCDFHandler.variables["lat_reference_point"], "provenance", "https://github.com/terraref/reference-data/issues/32 by Dr. David LeBauer")
 
         lon_pt_var = netCDFHandler.createVariable("lon_reference_point", "f8")
         lon_pt_var[...] = lon_pt
-        setattr(netCDFHandler.variables["lon_reference_point"], "units", "degrees_east")
+        setattr(netCDFHandler.variables["lon_reference_point"], "units", "degrees")
         setattr(netCDFHandler.variables["lon_reference_point"], "long_name", "Longitude of the master reference point at southeast corner of field")
         setattr(netCDFHandler.variables["lon_reference_point"], "provenance", "https://github.com/terraref/reference-data/issues/32 by Dr. David LeBauer")
 

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -386,7 +386,7 @@ class DataContainer(object):
         setattr(netCDFHandler.variables["lats"], "comment", "increasing toward the North direction, always positive")
 
         lons = netCDFHandler.createVariable("lons", "f8", ("y",))
-        lats[...] = geo_data["longitudes"]
+        lons[...] = geo_data["longitudes"]
         setattr(netCDFHandler.variables["lons"], "units", "degrees")
         setattr(netCDFHandler.variables["lons"], "long_name", "The precise longitude value for each pixel in the picture")
         setattr(netCDFHandler.variables["lats"], "comment", "decreasing toward the West direction, always negative")

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -301,43 +301,43 @@ class DataContainer(object):
 
         latSe = netCDFHandler.createVariable("lat_img_se", "f8")
         latSe[...] = float(lat_se)
-        setattr(netCDFHandler.variables["lat_img_se"], "units", "degrees_north")
+        setattr(netCDFHandler.variables["lat_img_se"], "units", "degrees")
         setattr(netCDFHandler.variables["lat_img_se"], "long_name", "Latitude of southeast corner of image")
 
         # have a "x_y_img_se" in meters, double
         lonSe = netCDFHandler.createVariable("lon_img_se", "f8")
         lonSe[...] = float(lon_se)
-        setattr(netCDFHandler.variables["lon_img_se"], "units", "degrees_east")
+        setattr(netCDFHandler.variables["lon_img_se"], "units", "degrees")
         setattr(netCDFHandler.variables["lon_img_se"], "long_name", "Longitude of southeast corner of image")
 
         latSw = netCDFHandler.createVariable("lat_img_sw", "f8")
         latSw[...] = float(lat_sw)
-        setattr(netCDFHandler.variables["lat_img_sw"], "units", "degrees_north")
+        setattr(netCDFHandler.variables["lat_img_sw"], "units", "degrees")
         setattr(netCDFHandler.variables["lat_img_sw"], "long_name", "Latitude of southwest corner of image")
 
         lonSw = netCDFHandler.createVariable("lon_img_sw", "f8")
         lonSw[...] = float(lon_sw)
-        setattr(netCDFHandler.variables["lon_img_sw"], "units", "degrees_east")
+        setattr(netCDFHandler.variables["lon_img_sw"], "units", "degrees")
         setattr(netCDFHandler.variables["lon_img_sw"], "long_name", "Longitude of southwest corner of image")
 
         latNe = netCDFHandler.createVariable("lat_img_ne", "f8")
         latNe[...] = float(lat_ne)
-        setattr(netCDFHandler.variables["lat_img_ne"], "units", "degrees_north")
+        setattr(netCDFHandler.variables["lat_img_ne"], "units", "degrees")
         setattr(netCDFHandler.variables["lat_img_ne"], "long_name", "Latitude of northeast corner of image")
 
         lonNe = netCDFHandler.createVariable("lon_img_ne", "f8")
         lonNe[...] = float(lon_ne)
-        setattr(netCDFHandler.variables["lon_img_ne"], "units", "degrees_east")
+        setattr(netCDFHandler.variables["lon_img_ne"], "units", "degrees")
         setattr(netCDFHandler.variables["lon_img_ne"], "long_name", "Longitude of northeast corner of image")
 
         latNw = netCDFHandler.createVariable("lat_img_nw", "f8")
         latNw[...] = float(lat_nw)
-        setattr(netCDFHandler.variables["lat_img_nw"], "units", "degrees_north")
+        setattr(netCDFHandler.variables["lat_img_nw"], "units", "degrees")
         setattr(netCDFHandler.variables["lat_img_nw"], "long_name", "Latitude of northwest corner of image")
 
         lonNw = netCDFHandler.createVariable("lon_img_nw", "f8")
         lonNw[...] = float(lon_nw)
-        setattr(netCDFHandler.variables["lon_img_nw"], "units", "degrees_east")
+        setattr(netCDFHandler.variables["lon_img_nw"], "units", "degrees")
         setattr(netCDFHandler.variables["lon_img_nw"], "long_name", "Longitude of northwest corner of image")
 
         xSe = netCDFHandler.createVariable("x_img_se", "f8")

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -383,13 +383,13 @@ class DataContainer(object):
 
         lats = netCDFHandler.createVariable("latitude", "f8", ("x",))
         lats[...] = geo_data["latitudes"]
-        setattr(netCDFHandler.variables["latitude"], "units", "degree")
+        setattr(netCDFHandler.variables["latitude"], "units", "degree_north")
         setattr(netCDFHandler.variables["latitude"], "long_name", "The precise latitude value for each pixel in the picture")
         setattr(netCDFHandler.variables["latitude"], "comment", "increasing toward the North direction, always positive")
 
         lons = netCDFHandler.createVariable("longitude", "f8", ("y",))
         lons[...] = geo_data["longitudes"]
-        setattr(netCDFHandler.variables["longitude"], "units", "degree")
+        setattr(netCDFHandler.variables["longitude"], "units", "degree_east")
         setattr(netCDFHandler.variables["longitude"], "long_name", "The precise longitude value for each pixel in the picture")
         setattr(netCDFHandler.variables["longitude"], "comment", "decreasing toward the West direction, always negative")
 

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -262,18 +262,18 @@ class DataContainer(object):
 
         ### If failed to get the georeference values, pre_fill all the values with _FillValue=1e36 and close. ###
         if geo_data["x_coordinates"] is None:
-            x = netCDFHandler.createVariable("x", "f8", fill_value=1e36)
-            y = netCDFHandler.createVariable("y", "f8", fill_value=1e36)
-            latSe = netCDFHandler.createVariable("lat_img_se", "f8", fill_value=1e36)
-            lonSe = netCDFHandler.createVariable("lon_img_se", "f8", fill_value=1e36)
-            latSw = netCDFHandler.createVariable("lat_img_sw", "f8", fill_value=1e36)
-            lonSw = netCDFHandler.createVariable("lon_img_sw", "f8", fill_value=1e36)
-            latNe = netCDFHandler.createVariable("lat_img_ne", "f8", fill_value=1e36)
-            lonNe = netCDFHandler.createVariable("lon_img_ne", "f8", fill_value=1e36)
-            latNw = netCDFHandler.createVariable("lat_img_nw", "f8", fill_value=1e36)
-            lonNw = netCDFHandler.createVariable("lon_img_nw", "f8", fill_value=1e36)
-            lats  = netCDFHandler.createVariable("lats", "f8", fill_value=1e36)
-            lons  = netCDFHandler.createVariable("lons", "f8", fill_value=1e36)
+            x = netCDFHandler.createVariable("x", "f8", fill_value=NCATTRS["_FillValue"])
+            y = netCDFHandler.createVariable("y", "f8", fill_value=NCATTRS["_FillValue"])
+            latSe = netCDFHandler.createVariable("lat_img_se", "f8", fill_value=NCATTRS["_FillValue"])
+            lonSe = netCDFHandler.createVariable("lon_img_se", "f8", fill_value=NCATTRS["_FillValue"])
+            latSw = netCDFHandler.createVariable("lat_img_sw", "f8", fill_value=NCATTRS["_FillValue"])
+            lonSw = netCDFHandler.createVariable("lon_img_sw", "f8", fill_value=NCATTRS["_FillValue"])
+            latNe = netCDFHandler.createVariable("lat_img_ne", "f8", fill_value=NCATTRS["_FillValue"])
+            lonNe = netCDFHandler.createVariable("lon_img_ne", "f8", fill_value=NCATTRS["_FillValue"])
+            latNw = netCDFHandler.createVariable("lat_img_nw", "f8", fill_value=NCATTRS["_FillValue"])
+            lonNw = netCDFHandler.createVariable("lon_img_nw", "f8", fill_value=NCATTRS["_FillValue"])
+            lats  = netCDFHandler.createVariable("lats", "f8", fill_value=NCATTRS["_FillValue"])
+            lons  = netCDFHandler.createVariable("lons", "f8", fill_value=NCATTRS["_FillValue"])
 
             netCDFHandler.close()
             return


### PR DESCRIPTION
1. If failed to get the georeference data, pre-fill all of them (x, y, lat, lon, etc.) with _FillValue = 1e36. The fixed data (reference point, history, etc.) will still be normally recorded. In this case, we will not have x and y dimensions (because we cannot collect them).

2. Add the latitude and longitude values of all the pixels.

- Had already been tested with SWIR data (06/28), VNIR data (10/06) and 1*1 tiny data on ROGER.