### PR TITLE
removed the arg @drc_spt from ncap2 cmd-line as crashing on Docker

### DIFF
--- a/hyperspectral/hyperspectral_calibration.nco
+++ b/hyperspectral/hyperspectral_calibration.nco
@@ -22,7 +22,7 @@
 
 // Defaults for values not provided on command-line
 if(!exists(clb_nbr)) *clb_nbr=73; // [nbr] Calibration number
-if(!exists(drc_spt)) *drc_spt="."; // [sng] Script directory
+//if(!exists(drc_spt)) *drc_spt="."; // [sng] Script directory
 
 // Change hyperspectral camera wavelengths from nm to m (SI)
 wavelength*=1.0e-9; // [m]

--- a/hyperspectral/hyperspectral_workflow.sh
+++ b/hyperspectral/hyperspectral_workflow.sh
@@ -656,7 +656,7 @@ for ((fl_idx=0;fl_idx<${fl_nbr};fl_idx++)); do
 	drc_spt_att="@drc_spt='\"${drc_spt}\"'" 
 	# NCO_PATH environment variable required for hyperspectral_calibration.nco to find hyperspectral_spectralon_reflectance_factory.nco
 	export NCO_PATH="${drc_spt}"
-	cmd_clb[${fl_idx}]="ncap2 -A ${nco_opt} -s ${drc_spt_att} -S ${drc_spt}/hyperspectral_calibration.nco ${clb_in} ${clb_in}"
+	cmd_clb[${fl_idx}]="ncap2 -A ${nco_opt} -S ${drc_spt}/hyperspectral_calibration.nco ${clb_in} ${clb_in}"
 	if [ ${dbg_lvl} -ge 1 ]; then
 	    echo ${cmd_clb[${fl_idx}]}
 	fi # !dbg


### PR DESCRIPTION
HI Charlie,
 have removed the var definition    "drc_spt" from the ncap2 command line   in hyperspectral_workflow.sh 
 
and also  commented out in hyperspectral_calibration.nco the line 
if(!exists(drc_spt)) *drc_spt="."; // [sng] Script directory 

As it was causing ncap2 to craash out on Docker.  
Will fully investigae the problem later this week when i get some time

...Henry 

 