### PR TITLE
Add Solar Zenith Angle Variable

### DIFF
--- a/hyperspectral/hyperspectral_calculation.py
+++ b/hyperspectral/hyperspectral_calculation.py
@@ -59,68 +59,38 @@ def _julian_date(time_date):
         
         
 def solar_zenith_angle(time_date):
-    '''
-    Calculate the solar zenith angle based on the datetime object given
-    '''
-    
-    latitude  = Decimal(33)  + Decimal(4.47)   / Decimal(60)
-    longitude = Decimal(-111)- Decimal(58.485) / Decimal(60)
-    
-    getcontext().prec = 8
-    julian_date = _julian_date(time_date)
-    actural_day = Decimal(julian_date)
-    
-    ### Sun & Earth Data ###
-    long_perihelion = Decimal(282.9404) + Decimal(4.70935e-5) * actural_day
-    eccentricity    = Decimal(0.016709) - Decimal(1.151e-9)   * actural_day
-    anomaly_degree  = (Decimal(356.047) + Decimal(0.9856002585)*actural_day) % Decimal(360)
-    
-    sun_mean_long   = long_perihelion + anomaly_degree
-    sun_obliquity   = Decimal(23.4393)- Decimal(3.563e-7) * actural_day
-    auxiliary_angle = anomaly_degree + (Decimal(180)/Decimal(pi)) * eccentricity *\
-                      Decimal(sin(anomaly_degree*Decimal(pi)/Decimal(180))) *\
-                      (Decimal(1)+eccentricity*Decimal(cos(anomaly_degree*Decimal(pi)/Decimal(180))))
-            
-    x_rectan_coord  = Decimal(cos(auxiliary_angle*Decimal(pi/180))) - eccentricity
-    y_rectan_coord  = Decimal(sin(auxiliary_angle*Decimal(pi/180))) * Decimal(sqrt(float(Decimal(1)-\
-                      eccentricity**Decimal(2))))    
 
-    distance        = Decimal(sqrt(float(x_rectan_coord**2+y_rectan_coord**2)))
-    true_anomaly    = Decimal(atan2(y_rectan_coord, x_rectan_coord))*Decimal(180/pi)
-    sun_longitude   = true_anomaly + long_perihelion
+    latitude = 33 + 4.47 / 60
     
-    x_ecliptic      = distance*Decimal(cos(sun_longitude*Decimal(pi/180)))
-    y_ecliptic      = distance*Decimal(sin(sun_longitude*Decimal(pi/180)))
-    z_ecliptic      = Decimal(0.0)
+    days_offset       = time_date - datetime(year=time_date.year,month=1,day=1) +\
+                        timedelta(days=1)
+    numerical_cal_day = Decimal(days_offset.days) + Decimal(days_offset.seconds) /\
+                        Decimal(86340)
     
-    x_equitorial    = x_ecliptic
-    y_equitorial    = y_ecliptic*Decimal(cos(sun_obliquity*Decimal(pi/180)))+\
-                      z_ecliptic*Decimal(sin(sun_obliquity*Decimal(pi/180)))
-    z_equitorial    = y_ecliptic*Decimal(sin(Decimal(23.4406)*Decimal(pi/180)))+\
-                      z_ecliptic*Decimal(cos(sun_obliquity*Decimal(pi/180)))
+    theta = Decimal(2)*Decimal(pi)*numerical_cal_day/Decimal(365)
     
-    distance        = (x_equitorial**2+y_equitorial**2+z_equitorial**2)**(1/2)
-    delta           = Decimal(asin(z_equitorial/distance))*Decimal(180/pi)
-    right_ascension = Decimal(atan2(y_equitorial, x_equitorial))*Decimal(180/pi)
+    eccentricity_fac = Decimal(1.000110)+\
+                       Decimal(cos(theta))*Decimal(0.034221)+\
+                       Decimal(sin(theta))*Decimal(0.001280)+\
+                       Decimal(cos(Decimal(2)*theta))*Decimal(0.000719)+\
+                       Decimal(sin(Decimal(2)*theta))*Decimal(0.000077)
     
-    uth             = Decimal(time_date.hour)+Decimal(time_date.minute)/Decimal(60)+\
-                      Decimal(time_date.second)/Decimal(3600)
-    gmst            = ((sun_longitude+Decimal(180))%Decimal(360))/Decimal(15)
-    loc_sideral_t   = gmst + uth + longitude / Decimal(15)
-
-    ### Right Ascension to Hour Angle ###
-    hour_angle      = loc_sideral_t*Decimal(15) - right_ascension
+    solar_decline    = Decimal(0.006918) - Decimal(0.399912)*Decimal(cos(theta))+\
+                                           Decimal(0.070257)*Decimal(sin(theta))-\
+                                           Decimal(0.006758)*Decimal(cos(Decimal(2)*theta))+\
+                                           Decimal(0.000907)*Decimal(sin(Decimal(2)*theta))-\
+                                           Decimal(0.002697)*Decimal(cos(Decimal(3)*theta))+\
+                                           Decimal(0.001480)*Decimal(sin(Decimal(3)*theta))
+                        
+    sin_latitude     = Decimal(sin(radians(latitude)))
+    sin_delta        = Decimal(sin(solar_decline))
+    cos_latitude     = Decimal(cos(radians(latitude)))
+    cos_delta        = Decimal(cos(solar_decline))
     
-    actural_x       = Decimal(cos(hour_angle*Decimal(pi/180)))*Decimal(cos(delta*Decimal(pi/180)))
-    actural_z       = Decimal(sin(delta*Decimal(pi/180)))
+    cphase = Decimal(cos(Decimal(2*pi)*numerical_cal_day))
+    cos_solar_zen_ang = sin_latitude*sin_delta-cos_latitude*cos_delta*cphase
     
-    x_rotation      = actural_x*Decimal(cos((Decimal(90)-latitude)*Decimal(pi)/Decimal(180)))-\
-                      actural_z*Decimal(sin((Decimal(90)-latitude)*Decimal(pi)/Decimal(180)))
-    z_rotation      = actural_x*Decimal(sin((Decimal(90)-latitude)*Decimal(pi/180)))+\
-                      actural_z*Decimal(cos((Decimal(90)-latitude)*Decimal(pi/180)))
-
-    ### Zenith Angle = 90 - Elevation Angle ###  
-    return 90 - abs(Decimal(asin(z_rotation))*Decimal(180/pi))
+    return float(Decimal(acos(cos_solar_zen_ang)/pi)*Decimal(180))
 
 
 def pixel2Geographic(jsonFileLocation, headerFileLocation, cameraOption, downsampled=False):

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -81,9 +81,9 @@ import time
 import os
 import re
 import math
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from netCDF4 import Dataset, stringtochar
-from hyperspectral_calculation import pixel2Geographic, REFERENCE_POINT
+from hyperspectral_calculation import pixel2Geographic, solar_zenith_angle, REFERENCE_POINT
 
 _UNIT_DICTIONARY = {'m':   'meter',
                     's':   'second', 
@@ -200,6 +200,11 @@ class DataContainer(object):
         setattr(frameTime, "calender", "gregorian")
         setattr(frameTime, "notes",    "Each time of the scanline of the y taken")
 
+        solar_zenith_ang = netCDFHandler.createVariable("solar_zenith_angle", "f8", ("time",))
+        solar_zenith_ang[...] = [solar_zenith_angle(datetime(year=1970,month=1,day=1)+timedelta(days=time_member)) for time_member in tempFrameTime]
+        setattr(solar_zenith_ang, "units", "degree")
+        setattr(solar_zenith_ang, "long_name", "Solar Zenith Angle")
+        setattr(solar_zenith_ang, "notes", "The angle of the sun comparing to the vertical axis of the Cartesian Coordinate")
         ########################### Adding geographic positions ###########################
 
         if "scanSpeedInMPerS" in dir(netCDFHandler.groups["gantry_system_variable_metadata"]):

--- a/hyperspectral/hyperspectral_metadata.py
+++ b/hyperspectral/hyperspectral_metadata.py
@@ -204,6 +204,7 @@ class DataContainer(object):
         solar_zenith_ang[...] = [solar_zenith_angle(datetime(year=1970,month=1,day=1)+timedelta(days=time_member)) for time_member in tempFrameTime]
         setattr(solar_zenith_ang, "units", "degree")
         setattr(solar_zenith_ang, "long_name", "Solar Zenith Angle")
+        setattr(solar_zenith_ang, "acknowledgements", "Algorithm provided by Charles S. Zender, this Python implementation was translated from his original C program")
         setattr(solar_zenith_ang, "notes", "The angle of the sun comparing to the vertical axis of the Cartesian Coordinate")
         ########################### Adding geographic positions ###########################
 

--- a/hyperspectral/hyperspectral_test.py
+++ b/hyperspectral/hyperspectral_test.py
@@ -257,6 +257,13 @@ class HyperspectralWorkflowTest(unittest.TestCase):
         self.assertFalse(result, msg="The graph is over reflected (i.e., has the pixel grater than the max. planet reflectance, now = "+\
                                       str(MAXIMUM_PLANT_REFLECTANCE)+" )")
 
+    def testSolarZenithAngleInReseaonableRange(self):
+        self.graph  = np.array(self.masterNetCDFHandler.variables["solar_zenith_angle"])
+        result_over = (self.graph > 90).any()
+        result_lower = (self.graph < 0).any()
+        self.assertFalse(result_over and result_lower, msg="The graph is over reflected (i.e., has the pixel grater than the max. planet reflectance, now = "+\
+                                      str(MAXIMUM_PLANT_REFLECTANCE)+" )")
+
     @unittest.expectedFailure
     def testCalibrationGraphIsOverExposured(self):
         self.graph = np.array(self.masterNetCDFHandler.variables["xps_img"])

--- a/hyperspectral/hyperspectral_test.py
+++ b/hyperspectral/hyperspectral_test.py
@@ -15,7 +15,7 @@ and will take one or two samples to check the values.
 
 ==============================================================================
 To run the test from the commandline, do:
-python hyperspectral_test.py <input_netCDF_file> <verbosity_level> <maximum_planet_reflectance>
+python hyperspectral_test.py <input_netCDF_file> <verbosity_level> <maximum_plant_reflectance>
 
 * verbosity level can be 0, 1 or 2 (from the quietest to the most verbose)
 
@@ -50,11 +50,8 @@ NOTES:
 EXPECTED_NUMBER_OF_GROUPS     = 6
 EXPECTED_NUMBER_OF_DIMENSIONS = 4
 TEST_FILE_DIRECTORY           = None
-MAXIMUM_PLANT_REFLECTANCE     = 0
-DEFAULT_PLANT_REFLECTANCE     = 0.6
-SATURATED_EXPOSURE            = 0
+MAXIMUM_PLANT_REFLECTANCE     = 0.6
 DEFAULT_SATURATED_EXPOSURE    = 2**16 - 1
-MAXIMUM_SATURATED_REFLECTANCE = 0
 
 
 
@@ -254,14 +251,14 @@ class HyperspectralWorkflowTest(unittest.TestCase):
     def testCalibrationGraphIsOverReflected(self):
         self.graph = np.array(self.masterNetCDFHandler.variables["rfl_img"])
         result = (self.graph > MAXIMUM_PLANT_REFLECTANCE).any()
-        self.assertFalse(result, msg="The graph is over reflected (i.e., has the pixel grater than the max. planet reflectance, now = "+\
+        self.assertFalse(result, msg="The graph is over reflected (i.e., has the pixel grater than the max. plant reflectance, now = "+\
                                       str(MAXIMUM_PLANT_REFLECTANCE)+" )")
 
     def testSolarZenithAngleInReseaonableRange(self):
         self.graph  = np.array(self.masterNetCDFHandler.variables["solar_zenith_angle"])
         result_over = (self.graph > 90).any()
         result_lower = (self.graph < 0).any()
-        self.assertFalse(result_over and result_lower, msg="The graph is over reflected (i.e., has the pixel grater than the max. planet reflectance, now = "+\
+        self.assertFalse(result_over and result_lower, msg="The graph is over reflected (i.e., has the pixel grater than the max. plant reflectance, now = "+\
                                       str(MAXIMUM_PLANT_REFLECTANCE)+" )")
 
     @unittest.expectedFailure
@@ -278,18 +275,16 @@ if __name__ == "__main__":
                              help='The path to the final output')
     test_parser.add_argument('verbosity', type=int, nargs='?', default=3,
                              help='The verbosity of the test report (from 1 <least verbose> to 3 <the most verbose>)')
-    test_parser.add_argument('maximum_planet_reflectance', type=float, nargs='?', default=DEFAULT_PLANT_REFLECTANCE,
-                             help='The maximum planet reflectance that has physical meaning (default=0.6)')
+    test_parser.add_argument('maximum_plant_reflectance', type=float, nargs='?', default=MAXIMUM_PLANT_REFLECTANCE,
+                             help='The maximum plant reflectance that has physical meaning (default=0.6)')
     test_parser.add_argument('saturated_exposure', type=int, nargs='?', default=DEFAULT_SATURATED_EXPOSURE,
                              help='The maximum saturated exposure that has physical meaning (default=2^16-1)')
 
     args = test_parser.parse_args()
 
-    TEST_FILE_DIRECTORY = sys.argv[1]
-    MAXIMUM_SATURATED_REFLECTANCE = float(sys.argv[-1]) if len(sys.argv) == 4 else 0.4
     TEST_FILE_DIRECTORY       = args.input_file_path[0]
-    MAXIMUM_PLANT_REFLECTANCE = args.maximum_planet_reflectance
-    SATURATED_EXPOSURE        = args.saturated_exposure
+    MAXIMUM_PLANT_REFLECTANCE = args.maximum_plant_reflectance
+    DEFAULT_SATURATED_EXPOSURE= args.saturated_exposure
     testSuite   = unittest.TestLoader().loadTestsFromTestCase(HyperspectralWorkflowTest)
     runner      = unittest.TextTestRunner(verbosity=args.verbosity).run(testSuite)
     returnValue = runner.wasSuccessful()


### PR DESCRIPTION
Now the hyperspectral output will have a variable "solar_zenith_angle" with dimension "time" showing as below (by ncks)
```bash
...
    double solar_zenith_angle(time) ;
      solar_zenith_angle:units = "degree" ;
      solar_zenith_angle:long_name = "Solar Zenith Angle" ;
      solar_zenith_angle:notes = "The angle of the sun comparing to the vertical axis of the Cartesian Coordinate" ;
...
```

Since these functions were translated from MATLAB, the result is still not flawless (partially because Python is not an ideal language for calculation, although it has a lot of math libraries). 

Here is the result from Python Solar Zenith Angle calculator @ 2016/06/01 in Maricopa field
![sza python](https://cloud.githubusercontent.com/assets/11842208/25790096/da68aaa4-336a-11e7-87de-ad67c45816e4.png)

The angles in the morning are obviously incorrect.
The result from Matlab at the same time in Maricopa field (I think this one is correct)
![untitled](https://cloud.githubusercontent.com/assets/11842208/25790114/08dae320-336b-11e7-8212-a62fbd4b2076.png)


P.S. Please only look at the last commit; rest of the commits are hanging around because another pull request is still waiting to be merged. This PR is in a new branch called "solar_zenith_angle"
