### PR TITLE
Overhaul calibration process for VNIR/SWIR

### DIFF
--- a/hyperspectral/Dockerfile
+++ b/hyperspectral/Dockerfile
@@ -11,15 +11,13 @@ RUN apt-get update && apt-get upgrade -y -q \
     && apt-get install -y  --no-install-recommends \
         curl \
         bzip2 \
-        python \
-        python-pip \
+        python3 \
+        python3-pip \
         git \
         libpng-dev \
         libfreetype6-dev \
         python-matplotlib \
         libudunits2-dev
-
-RUN pip install --upgrade pip setuptools pika
 
 # install conda
 USER extractor
@@ -40,13 +38,12 @@ RUN ~/anaconda2/bin/conda config --add channels conda-forge \
          geos \
          udunits2
 
+ENV PATH="/home/extractor/anaconda2/bin:${PATH}"
+
 # install pyclowder and terrautils
 RUN pip install --user -r https://opensource.ncsa.illinois.edu/bitbucket/projects/CATS/repos/pyclowder2/raw/requirements.txt \
     && pip install --user git+https://opensource.ncsa.illinois.edu/bitbucket/scm/cats/pyclowder2.git \
-    && pip install --user -r https://raw.githubusercontent.com/terraref/terrautils/master/requirements.txt \
-    && pip install --user git+https://github.com/terraref/terrautils.git
-
-RUN pip install --user spectral
+    && pip install --user terrautils laspy spectral pika
 
 USER root
 RUN apt-get update && apt-get upgrade -y -q \
@@ -71,6 +68,5 @@ ENV RABBITMQ_EXCHANGE="terra" \
     RABBITMQ_QUEUE="terra.hyperspectral" \
     MAIN_SCRIPT="terra_hyperspectral.py" \
     CLOWDER_SPACE="5bdc8f174f0cb2fdaaf3148e" \
-    PATH="/home/extractor/anaconda2/bin:${PATH}" \
     UDUNITS2_XML_PATH="/usr/share/xml/udunits/udunits2.xml" \
     HDF5_USE_FILE_LOCKING="FALSE"

--- a/hyperspectral/Dockerfile
+++ b/hyperspectral/Dockerfile
@@ -50,7 +50,7 @@ RUN pip install --user spectral
 
 USER root
 RUN apt-get update && apt-get upgrade -y -q \
-    && apt-get install -y  --no-install-recommends vim
+    && apt-get install -y  --no-install-recommends vim libnetcdf-dev default-jdk
 USER extractor
 
 COPY logging_config.json /var/log/

--- a/hyperspectral/Dockerfile
+++ b/hyperspectral/Dockerfile
@@ -50,7 +50,7 @@ RUN pip install --user spectral
 
 USER root
 RUN apt-get update && apt-get upgrade -y -q \
-    && apt-get install -y  --no-install-recommends vim libnetcdf-dev default-jdk
+    && apt-get install -y  --no-install-recommends vim libnetcdf-dev
 USER extractor
 
 COPY logging_config.json /var/log/

--- a/hyperspectral/calibrate.py
+++ b/hyperspectral/calibrate.py
@@ -14,13 +14,169 @@ output: the reflectance image
 import json
 import numpy as np
 import os
-import subprocess
 import spectral.io.envi as envi
 from netCDF4 import Dataset
+from PIL import Image
+from datetime import date, datetime, timedelta
+
+from hyperspectral_calculation import pixel2Geographic, test_pixel2Geographic, solar_zenith_angle
 
 
-raw_root = "/home/extractor/sites/ua-mac/raw_data"
+raw_root = "/home/extractor/hs_calib"
 calib_root = "/home/extractor"
+
+
+def create_empty_netCDF(raw_file, out_file):
+    if not os.path.isdir(os.path.dirname(out_file)):
+        os.makedirs(os.path.dirname(out_file))
+
+    empty = Dataset(out_file, "w", format="NETCDF4")
+
+    # Get values dynamically from Header file
+    hdr_file = raw_file + ".hdr"
+    hdr_samples = None
+    hdr_lines = None
+    hdr_bands = None
+    with open(hdr_file, 'r') as hdr:
+        for l in hdr.readlines():
+            if l.startswith('samples'):
+                hdr_samples = int(l.split("=")[1].strip())
+            if l.startswith('lines'):
+                hdr_lines = int(l.split("=")[1].strip())
+            if l.startswith('bands'):
+                hdr_bands = int(l.split("=")[1].strip())
+            if hdr_samples is not None and hdr_lines is not None and hdr_bands is not None:
+                break
+
+    # Get number of frames
+    frame_file = raw_file.replace("_raw", "_frameIndex.txt")
+    with open(frame_file, 'r') as frames:
+        num_frames = len(frames.readlines()[1:])
+
+    # add dimensions
+    empty.createDimension("wavelength", hdr_bands)
+    empty.createDimension("x", hdr_lines)
+    empty.createDimension("y", hdr_samples)
+    empty.createDimension("time", num_frames)
+
+    # raw reflectance
+    # TODO: Do we need this if it is never populated?
+    v = empty.createVariable("xps_img", "u2", ("wavelength", "x", "y"))
+    v.long_name = "Exposure counts"
+    v.meaning = "Counts on scale from 0 to 2^16-1 = 65535"
+    v.units = "1"
+
+    # calibrated reflectance
+    v = empty.createVariable("rfl_img", "f8", ("wavelength", "x", "y"))
+    v.long_name = "Reflectance of image"
+    v.standard_name = "surface_albedo"
+    v.units = "1"
+
+    # solar zenith angle
+    v = empty.createVariable("solar_zenith_angle", "f8", ("time"))
+    v.long_name = "Solar Zenith Angle"
+    v.units = "degree"
+    v.notes = "The angle of the sun comparing to the vertical axis of the Cartesian Coordinate"
+    v.acknowledgements = "Algorithm provided by Charles S. Zender, this Python implementation was translated from his original C program"
+
+    # frametime
+    v = empty.createVariable("frametime", "f8", ("time"))
+    v.units = "days since 1970-01-01 00:00:00"
+    v.calendar = "gregorian"
+    v.notes = "date stamp per each scanline"
+
+    # raw location
+    v = empty.createVariable("x", "f8", ("x"))
+    v.units = "meter"
+    v.long_name = "North distance from southeast corner of field"
+    v = empty.createVariable("y", "f8", ("y"))
+    v.units = "meter"
+    v.long_name = "West distance from southeast corner of field"
+    v = empty.createVariable("latitude", "f8", ("x"))
+    v.units = "degree_north"
+    v.long_name = "The precise latitude value for each pixel in the picture"
+    v = empty.createVariable("longitude", "f8", ("y"))
+    v.units = "degree_east"
+    v.long_name = "The precise longitude value for each pixel in the picture"
+
+    # pixel sizes
+    v = empty.createVariable("x_pxl_sz", "f8")
+    v.long_name = "x coordinate length of a single pixel in VNIR images"
+    v.units = "meters"
+    v = empty.createVariable("y_pxl_sz", "f8")
+    v.long_name = "y coordinate length of a single pixel in pictures captured by SWIR and VNIR camera"
+    v.units = "meters"
+
+    # gantry positional variables
+    v = empty.createVariable("x_img_ne", "f8")
+    v.long_name = "Northeast corner of image, north distance to reference point"
+    v.units = "meters"
+    v = empty.createVariable("x_img_nw", "f8")
+    v.long_name = "Northwest corner of image, north distance to reference point"
+    v.units = "meters"
+    v = empty.createVariable("x_img_se", "f8")
+    v.long_name = "Southeast corner of image, north distance to reference point"
+    v.units = "meters"
+    v = empty.createVariable("x_img_sw", "f8")
+    v.long_name = "Southwest corner of image, north distance to reference point"
+    v.units = "meters"
+    v = empty.createVariable("x_reference_point", "f8")
+    v.long_name = "x of the master reference point at southeast corner of field"
+    v.units = "meters"
+    v = empty.createVariable("y_img_ne", "f8")
+    v.long_name = "Northeast corner of image, west distance to reference point"
+    v.units = "meters"
+    v = empty.createVariable("y_img_nw", "f8")
+    v.long_name = "Northwest corner of image, west distance to reference point"
+    v.units = "meters"
+    v = empty.createVariable("y_img_se", "f8")
+    v.long_name = "Southeast corner of image, west distance to reference point"
+    v.units = "meters"
+    v = empty.createVariable("y_img_sw", "f8")
+    v.long_name = "Southwest corner of image, west distance to reference point"
+    v.units = "meters"
+    v = empty.createVariable("y_reference_point", "f8")
+    v.long_name = "y of the master reference point at southeast corner of field"
+    v.units = "meters"
+
+    # lat/lon positional variables
+    v = empty.createVariable("lat_img_ne", "f8")
+    v.long_name = "Latitude of northeast corner of image"
+    v.units = "degrees_north"
+    v = empty.createVariable("lat_img_nw", "f8")
+    v.long_name = "Latitude of northwest corner of image"
+    v.units = "degrees_north"
+    v = empty.createVariable("lat_img_se", "f8")
+    v.long_name = "Latitude of southeast corner of image"
+    v.units = "degrees_north"
+    v = empty.createVariable("lat_img_sw", "f8")
+    v.long_name = "Latitude of southwest corner of image"
+    v.units = "degrees_north"
+    v = empty.createVariable("lat_reference_point", "f8")
+    v.long_name = "Latitude of the master reference point at southeast corner of field"
+    v.units = "degrees_north"
+    v = empty.createVariable("lon_img_ne", "f8")
+    v.long_name = "Longitude of northeast corner of image"
+    v.units = "degrees_east"
+    v = empty.createVariable("lon_img_nw", "f8")
+    v.long_name = "Longitude of northwest corner of image"
+    v.units = "degrees_east"
+    v = empty.createVariable("lon_img_se", "f8")
+    v.long_name = "Longitude of southeast corner of image"
+    v.units = "degrees_east"
+    v = empty.createVariable("lon_img_sw", "f8")
+    v.long_name = "Longitude of southwest corner of image"
+    v.units = "degrees_east"
+    v = empty.createVariable("lon_reference_point", "f8")
+    v.long_name = "Longitude of the master reference point at southeast corner of field"
+    v.units = "degrees_east"
+
+    # add global attributes
+    empty.title = "None given"
+    empty.created_by = "nobody"
+    empty.history = "created with Python"
+
+    empty.close()
 
 # extract spectral profiles from environmentlogger.json
 def irradiance_time_extractor(camera_type, envlog_file):
@@ -120,8 +276,105 @@ def update_netcdf(inp, rfl_data, camera_type):
             dst.createVariable("rfl_img", "f4")
             dst.variables['rfl_img'] = rfl_data
 
+# calculate frame times and solar zenith angle
+def prepare_header_data(hdr_file, dataset_date):
+    date_tuple = datetime.strptime(dataset_date, "%Y-%m-%d").timetuple()
+    unix_basetime = date(year=1970, month=1, day=1)
+    time_split = date(year=date_tuple.tm_year, month=date_tuple.tm_mon, day=date_tuple.tm_mday) - unix_basetime
+
+    # Extract time of each frame from frameIndex
+    framelist = []
+    frame_file = hdr_file.replace("_raw.hdr", "_frameIndex.txt")
+    with open(frame_file, 'r') as frames:
+        for fl in frames.readlines()[1:]:
+            hour_tuple = datetime.strptime(fl.split()[1], "%H:%M:%S").timetuple()
+            framelist.append((time_split.total_seconds() + hour_tuple.tm_hour*3600.0 + hour_tuple.tm_min*60.0 +
+                              hour_tuple.tm_sec) / (3600.0*24.0))
+
+    sza = [solar_zenith_angle(datetime(year=1970, month=1, day=1) + timedelta(days=ftime)) for ftime in framelist]
+
+    return {
+        'frametime': framelist,
+        'solar_zenith_angle': sza
+    }
+
+# populate empty netCDF headers with metadata & geo information
+def update_netcdf_headers(nc_file, geodata, header_data):
+    with Dataset(nc_file, 'a', mmap=False) as src:
+        src["lat_img_ne"][...] = geodata["bbox_geojson"]["coordinates"][0][0][1]
+        src["lon_img_ne"][...] = geodata["bbox_geojson"]["coordinates"][0][0][0]
+        src["lat_img_nw"][...] = geodata["bbox_geojson"]["coordinates"][0][1][1]
+        src["lon_img_nw"][...] = geodata["bbox_geojson"]["coordinates"][0][1][0]
+        src["lat_img_sw"][...] = geodata["bbox_geojson"]["coordinates"][0][2][1]
+        src["lon_img_sw"][...] = geodata["bbox_geojson"]["coordinates"][0][2][0]
+        src["lat_img_se"][...] = geodata["bbox_geojson"]["coordinates"][0][3][1]
+        src["lon_img_se"][...] = geodata["bbox_geojson"]["coordinates"][0][3][0]
+
+        src["x_img_ne"][...] = geodata["x_coordinates"][-1]
+        src["y_img_ne"][...] = geodata["y_coordinates"][0]
+        src["x_img_nw"][...] = geodata["x_coordinates"][0]
+        src["y_img_nw"][...] = geodata["y_coordinates"][0]
+        src["x_img_sw"][...] = geodata["x_coordinates"][0]
+        src["y_img_sw"][...] = geodata["y_coordinates"][-1]
+        src["x_img_se"][...] = geodata["x_coordinates"][-1]
+        src["y_img_se"][...] = geodata["y_coordinates"][-1]
+
+        src["x_pxl_sz"][...] = geodata["x_pixel_size"]
+        src["y_pxl_sz"][...] = geodata["y_pixel_size"]
+        src["x_reference_point"][...] = geodata["x_reference"]
+        src["y_reference_point"][...] = geodata["y_reference"]
+
+        # TODO: hyperspectral_calculation has x/y swapped for these
+        src["x"][...] = geodata["y_coordinates"]
+        src["y"][...] = geodata["x_coordinates"]
+
+        src["frametime"][...] = header_data['frametime']
+        src["solar_zenith_angle"][...] = header_data['solar_zenith_angle']
+
+# replace rfl_img variable in netcdf with given matrix
+def update_netcdf_band(inp, band, band_data, camera_type):
+    if band % 10 == 0:
+        print("band: %s" % band)
+
+    if camera_type=='vnir_old':
+        inp["rfl_img"][band,:,:] = band_data
+    elif camera_type == "vnir_middle":
+        inp["rfl_img"][band,:,:] = band_data
+    else:
+        inp["rfl_img"][band,:,:] = band_data
+
+# Get the rgb bands from netcdf file and save as jpg image for quick view
+def convert_netcdf_to_jpg(out_file, out_path, camera_type, timestamp):
+    out_rgb = os.path.join(out_path, "%s_netcdf_L1_ua-mac_%s.jpg" % (camera_type.split("_")[0], timestamp)) # define output path and image name
+
+    # extract corresponding rgb bands from different netcdf files (VNIR or SWIR)
+    f = Dataset(out_file)
+    img_arr = np.asarray(f.variables['rfl_img'][:])
+    rgb = np.zeros((img_arr.shape[1],img_arr.shape[2],3),dtype=np.uint8)
+
+    if camera_type.startswith("swir"):
+        r = img_arr[24,:,:]; r *= 255.0/r.max()
+        g = img_arr[51,:,:]; g *= 255.0/g.max()
+        b = img_arr[120,:,:]; b *= 255.0/b.max()
+    else:
+        r = img_arr[376,:,:]; r *= 255.0/r.max()
+        g = img_arr[235,:,:]; g *= 255.0/g.max()
+        b = img_arr[95,:,:]; b *= 255.0/b.max()
+
+    rgb[:,:,0] = r; rgb[:,:,1] = g; rgb[:,:,2] = b
+
+    out_img = Image.fromarray(rgb)
+    out_img.save(out_rgb)
+
+    # free up memory
+    del img_arr; r; g; b; rgb
+
 # apply calibration algorithm to the raw data
-def apply_calibration(raw_filepath):
+def apply_calibration(raw_filepath, out_file, metadata=None):
+    if not os.path.exists(out_file):
+        print("Error: %s does not exist to calibrate" % out_file)
+        return
+
     print("Calibrating %s" % raw_filepath)
 
     # get necessary paths from path to _raw file
@@ -129,17 +382,7 @@ def apply_calibration(raw_filepath):
     raw_file = os.path.basename(raw_filepath)
     md_file = os.path.join(raw_dir, "%s_metadata.json" % raw_file[:-4])
     date = raw_filepath.split("/")[-3]
-    timestamp = raw_filepath.split("/")[-2]
-    envlog_dir   = os.path.join(raw_root, "EnvironmentLogger/%s" % date)
-
-    #     prepare output paths
-    print("Generating output")
-    out_path = os.path.dirname(raw_filepath.replace("raw_data", "Level_1").replace("SWIR", "swir_netcdf").replace("VNIR", "vnir_netcdf"))
-    if not os.path.isdir(out_path):
-        os.makedirs(out_path)
-    if os.path.isfile(out_path):
-        print("Output file already exists: skipping "+out_path)
-        return
+    envlog_dir = os.path.join(raw_root, "EnvironmentLogger/%s" % date)
 
     # determine type of sensor and age of camera
     if raw_filepath.find("VNIR") > -1:
@@ -172,28 +415,33 @@ def apply_calibration(raw_filepath):
 
     # load the raw data set
     print("Loading %s.hdr" % raw_filepath)
+    hdr_path = raw_filepath +'.hdr'
     try:
-        raw = envi.open(raw_filepath +'.hdr')
-        #        img_DN  = raw.load()
+        raw = envi.open(hdr_path)
         img_DN = raw.open_memmap()
-        #head_file = envi.read_envi_header(data_fullpath +'.hdr')
     except IOError:
         print('No such file named %s' % raw_filepath)
 
-    # Apply calibration procedure if camera_type == vnir_old, vnir_middle, vnir_new or swir_new. Since no calibration models are available for
-    # swir_old and swir_middle, so directly convert old&middel SWIR raw data to netcdf format
+    if metadata is None:
+        # TEST CODE
+        json_file = raw_filepath.replace("_raw", "_metadata.json")
+        geo = test_pixel2Geographic(json_file, hdr_path, camera_type.split("_")[0].upper())
+    else:
+        geo = pixel2Geographic(metadata, hdr_path, camera_type.split("_")[0].upper())
+
+    print("Updating netCDF headers")
+    header_data = prepare_header_data(hdr_path, date)
+    update_netcdf_headers(out_file, geo, header_data)
+
+    # Since no calibration models are available for swir_old_middle, directly convert the raw data to netcdf
     if camera_type =="swir_old_middle":
-        # Convert the raw swir_old and swir_middle data to netCDF
         img_DN = np.rollaxis(img_DN, 2, 0)
         # Generate output path and call the netCDF conversion function, convert the raw old&middle swir data to netcdf
-        out_path = os.path.dirname(raw_filepath.replace("raw_data", "Level_1").replace("SWIR", "swir_netcdf").replace("VNIR", "vnir_netcdf"))
-        out_file = os.path.join(out_path, "%s_netcdf_L1_ua-mac_%s.nc" % (camera_type.split("_")[0], timestamp))
         update_netcdf(out_file, img_DN, camera_type)
-
         # free up memory
         del img_DN
 
-    else: # when camera_type == vnir_old, vnir_middle, vnir_new or swir_new, apply pre-computed calibration models
+    else: # apply pre-computed calibration models
         # Load the previously created calibration models based on the camera_type
         best_matched = os.path.join(calib_root + "/" + "calibration_new", camera_type, 'best_matched_index.npy')
         bias = os.path.join(calib_root + "/" + "calibration_new", camera_type, 'bias_coeff.npy')
@@ -204,7 +452,6 @@ def apply_calibration(raw_filepath):
         envlog_spectra = np.array([], dtype=np.int64).reshape(0, num_bands_irradiance)
         for ef in os.listdir(envlog_dir):
             if ef.endswith("environmentlogger.json"):
-
                 time, spectrum = irradiance_time_extractor(camera_type,os.path.join(envlog_dir, ef))
                 envlog_tot_time += time
                 # print("concatenating %s onto %s" % (spectrum.shape, envlog_spectra.shape))
@@ -246,91 +493,16 @@ def apply_calibration(raw_filepath):
         irrad2DN = (g * test_irridance_re) + b
 
         # reflectance computation
-        print("Computing reflectance")
-        rfl_data  = img_DN/irrad2DN
-        rfl_data = np.rollaxis(rfl_data, 2, 0)
+        print("Computing reflectance and updating %s" % out_file)
+        with Dataset(out_file, 'a', mmap=False) as src:
+            # TODO: If file size is small enough, don't do this per-band but all at once
+            for band_ind in range(img_DN.shape[2]):
+                calibrated_band = img_DN[:,:,band_ind] / irrad2DN[:,band_ind]
+                update_netcdf_band(src, band_ind, calibrated_band, camera_type)
 
-        # free up memory
+        # Generate jpg format quick view image of final netcdf file
+        # TODO: Runs out of memory on large files
+        # convert_netcdf_to_jpg(out_file,out_path,camera_type,timestamp)
+
         del img_DN
-        del irrad2DN
-
-        # save as ENVI file (RGB bands: 392, 252, 127)
-        #out_file = os.path.join('ref_%s.hdr' % raw_file)
-        #envi.save_image(out_file, Ref, dtype=np.float32, interleave='bil', force = 'True', metadata=head_file)
-
-        # Save Ref as a .npy file
-        #out_file = os.path.join(out_path, 'ref_%s.npy' % raw_file)
-        #np.save(out_file, rfl_data)
-
-        # Write to nc file
-        out_file = os.path.join(out_path, "%s_netcdf_L1_ua-mac_%s.nc" % (camera_type.split("_")[0], timestamp))
-        update_netcdf(out_file, rfl_data, camera_type)
-
-        # free up memory
-        del rfl_data
-
-
-if __name__ == "__main__":
-    # TODO: This will come from the extractor message
-    input_paths = [
-    # swir_old
-        # NA os.path.join(raw_root, "SWIR/2017-04-16/2017-04-16__11-50-46-707/c6079666-b686-4481-9a4f-0663f5f43a6a_raw"),
-    # swir_new
-        # OK os.path.join(raw_root, "SWIR/2018-09-22/2018-09-22__13-21-35-977/05b7ad1a-a2d7-4dfc-bcec-b1a394ec0892_raw"),
-        # OK os.path.join(raw_root, "SWIR/2018-10-11/2018-10-11__12-11-43-420/dc60c7d5-24bc-432b-a7cb-98ac1da73154_raw"),
-    # vnir_old
-        # OK os.path.join(raw_root, "VNIR/2017-04-15/2017-04-15__11-33-42-265/76efd15f-928a-49f7-a008-4877b8842129_raw"),
-        # OK os.path.join(raw_root, "VNIR/2017-04-17/2017-04-17__16-39-35-738/a5096c7a-c052-4728-a29b-a5a6119c366c_raw"),
-        # OK os.path.join(raw_root, "VNIR/2017-04-17/2017-07-08__06-30-15-622/5154c9fc-0a51-4a4d-9c79-242539f057ad_raw"),
-        # os.path.join(raw_root, "VNIR/2017-05-13/2017-05-13__12-00-39-756/1bcc7cd0-1205-45a3-b4b3-cbcac6236754_raw"), # Killed
-        # os.path.join(raw_root, "VNIR/2017-06-18/2017-06-18__14-34-24-390/41a0b327-83ff-4131-b1fd-5ee5254760b6_raw"), # Killed
-        # os.path.join(raw_root, "VNIR/2017-07-27/2017-07-27__15-05-11-667/d1643679-bef3-4179-9912-d63bf4cd53c6_raw"),
-        os.path.join(raw_root, "VNIR/2017-08-23/2017-08-23__09-21-43-959/ea0e3408-ed1c-412d-aa68-e75ce2e902b1_raw"),
-    # vnir_middle
-        # NA os.path.join(raw_root, "VNIR/2018-08-18/2018-08-18__11-11-41-890/c5f4d50f-44ad-4e23-9d92-f10e62110ac7_raw"),
-        # NA os.path.join(raw_root, "VNIR/2018-10-08/2018-10-08__11-41-01-365/5e39a30f-d343-405e-a140-db26dc72eb59_raw"),
-    # vnir_new
-        # GEN os.path.join(raw_root, "VNIR/2019-06-17/2019-06-17__14-03-29-760/d51b6f4c-9246-4da8-9a6c-786bb1dc21bf_raw"),
-
-    ]
-
-    for p in input_paths:
-        apply_calibration(p)
-
-for sensor in ["VNIR", "SWIR"]:
-    sensor_dir = os.path.join(raw_root, sensor)
-    dates = os.listdir(sensor_dir)
-    for d in dates:
-        if d.startswith("2018") or d.startswith("2017"):
-            date_dir = os.path.join(sensor_dir, d)
-            timestamps = os.listdir(date_dir)
-            for ts in timestamps:
-                ts_dir = os.path.join(date_dir, ts)
-                flist = os.listdir(ts_dir)
-                for f in flist:
-                    if f.endswith("_raw"):
-                        fpath = os.path.join(ts_dir, f)
-                        rawsize = os.stat(fpath).st_size
-                        if rawsize > 8 * 1000000000:
-                            print("%s filesize %sGB exceeds available RAM" % (ts, int(rawsize/1000000000)))
-                        else:
-                            date = fpath.split("/")[-3]
-                            timestamp = fpath.split("/")[-2]
-
-                            out_path = os.path.dirname(fpath.replace("raw_data", "Level_1").replace("SWIR", "swir_netcdf").replace("VNIR", "vnir_netcdf"))
-                            out_file = os.path.join(out_path, "%s_netcdf_L1_ua-mac_%s.nc" % (sensor.lower(), timestamp))
-                            xps_file = out_file.replace(".nc", "_xps.nc")
-                            calib_file = out_file.replace(".nc", "_newrfl.nc")
-                            if not os.path.isfile(out_file):
-                                print("Generating .nc file")
-                                returncode = subprocess.call(["bash", "hyperspectral_workflow.sh", "-d", "1",
-                                                              "--output_xps_img", xps_file, "-i", fpath, "-o", out_file])
-                            if not os.path.isdir(os.path.join(raw_root, "EnvironmentLogger", d)):
-                                print("Missing EnvironmentLogger folder for %s - skipping" % d)
-                            elif not os.path.isfile(calib_file):
-                                print("Calibrating "+f)
-                                try:
-                                    apply_calibration(fpath)
-                                except:
-                                    print("Error calibrating %s" % f)
-                                    continue
+        print("All done")

--- a/hyperspectral/calibrate_empty.py
+++ b/hyperspectral/calibrate_empty.py
@@ -1,0 +1,334 @@
+"""
+*** Hyperspectral Image Calibration ***
+This module will process the raw data file and export ENVI files with variables
+stored its hdr file. (This is an initial version, more improvements are coming up. )
+
+input:   1) raw VNIR data;
+         2) spectral data from downwelling irradiance sensor
+
+output: the reflectance image
+
+@author: SLU Remote Sensing Lab
+"""
+
+import json
+import numpy as np
+import os
+import spectral.io.envi as envi
+from netCDF4 import Dataset
+
+
+raw_root = "/home/extractor/hs_calib"
+calib_root = "/home/extractor"
+
+
+def create_empty_netCDF(raw_file):
+    out_path = os.path.dirname(raw_file.replace("raw_data", "Level_1").replace("SWIR", "swir_netcdf").replace("VNIR", "vnir_netcdf"))
+    timestamp = raw_file.split("/")[-2]
+    if raw_file.find("VNIR") > -1:
+        camera_type = "vnir"
+    else:
+        camera_type = "swir"
+    out_file = os.path.join(out_path, "%s_netcdf_L1_ua-mac_%s.nc" % (camera_type, timestamp))
+
+    empty = Dataset(out_file, "w", format="NETCDF4")
+
+    # Get values dynamically from Header file
+    hdr_file = raw_file + ".hdr"
+    hdr_samples = None
+    hdr_lines = None
+    hdr_bands = None
+    with open(hdr_file, 'r') as hdr:
+        for l in hdr.readlines():
+            if l.startswith('samples'):
+                hdr_samples = int(l.split("=")[1].strip())
+            if l.startswith('lines'):
+                hdr_lines = int(l.split("=")[1].strip())
+            if l.startswith('bands'):
+                hdr_bands = int(l.split("=")[1].strip())
+            if hdr_samples is not None and hdr_lines is not None and hdr_bands is not None:
+                break
+
+    # add dimensions
+    empty.createDimension("wavelength", hdr_bands)
+    empty.createDimension("x", hdr_samples)
+    empty.createDimension("y", hdr_lines)
+
+    # add Variable double temperature(lat,lon)
+    t = empty.createVariable("xps_img", "u2", ("wavelength", "x", "y"))
+    t.long_name = "Exposure counts"
+    t.meaning = "Counts on scale from 0 to 2^16-1 = 65535"
+    t.units = "1"
+
+    empty.createVariable("rfl_img", "f4", ("wavelength", "x", "y"))
+
+    # add global attributes
+    empty.title = "None given"
+    empty.created_by = "nobody"
+    empty.history = "created with Python"
+
+    empty.close()
+
+# extract spectral profiles from environmentlogger.json
+def irradiance_time_extractor(camera_type, envlog_file):
+    # For the environmental logger records after 04/26/2016, there would be 24 files per day (1 file per hour, 5 seconds per record)
+    # Convert json fiel to dictionary format file
+    with open(envlog_file, "r") as fp:
+        lines = fp.readlines()
+        slines = "".join(lines)
+        js = json.loads(slines)
+
+    # assume that time stamp follows in 5 second increments across records since 5 sec/record
+    num_readings = len(js["environment_sensor_readings"])
+    if "spectrometers" in js["environment_sensor_readings"][0]:
+        if camera_type == "swir_new":
+            num_bands = len(js["environment_sensor_readings"][0]["spectrometers"]["NIRQuest-512"]["spectrum"])
+        else:
+            num_bands = len(js["environment_sensor_readings"][0]["spectrometers"]["FLAME-T"]["spectrum"])
+    else:
+        num_bands = len(js["environment_sensor_readings"][0]["spectrometer"]["spectrum"])
+
+    spectra = np.zeros((num_readings, num_bands))
+    times = []
+    for idx in range(num_readings):
+        # read time stamp
+        time_current = js["environment_sensor_readings"][idx]["timestamp"]
+        C = time_current.replace("."," ").replace("-"," ").replace(":","")
+        ArrayTime=C.split(" ")
+        time_current_r = int(ArrayTime[3])
+        times.append(time_current_r)
+
+        # read spectrum from irridiance sensors
+        if "spectrometers" in js["environment_sensor_readings"][idx]:
+            if camera_type == "swir_new":
+                spectrum = js["environment_sensor_readings"][0]["spectrometers"]["NIRQuest-512"]["spectrum"]
+            else:
+                spectrum = js["environment_sensor_readings"][idx]["spectrometers"]["FLAME-T"]["spectrum"]
+        else:
+            spectrum = js["environment_sensor_readings"][idx]["spectrometer"]["spectrum"]
+
+        spectra[idx,:] = spectrum
+
+    return times, spectra
+
+# replace rfl_img variable in netcdf with given matrix
+def update_netcdf(inp, rfl_data, camera_type):
+    print("Updating %s" % inp)
+
+    out = inp.replace(".nc", "_newrfl.nc")
+
+    with Dataset(inp) as src, Dataset(out, "w") as dst:
+        # copy global attributes all at once via dictionary
+        dst.setncatts(src.__dict__)
+        # copy dimensions
+        for name, dimension in src.dimensions.items():
+            dst.createDimension(name, (len(dimension) if not dimension.isunlimited() else None))
+
+        # copy all file data except for the excluded
+        for name, variable in src.variables.items():
+            if name == "Google_Map_View":
+                continue
+
+            # Create variables
+            var_dict = (src[name].__dict__)
+            if '_FillValue' in var_dict.keys():
+                x = dst.createVariable(name, variable.datatype, variable.dimensions, fill_value=var_dict['_FillValue'])
+                del var_dict['_FillValue']
+            else:
+                x = dst.createVariable(name, variable.datatype, variable.dimensions)
+
+            # Set variables to values
+            if name != "rfl_img":
+                print("...%s" % name)
+                dst[name][:] = src[name][:]
+            else:
+                if camera_type=='vnir_old':
+                    print("...%s (subset)" % name)
+                    dst[name][:679,:,:] = rfl_data
+                    # 679-955 set to NaN
+                    print("...NaNs")
+                    dst[name][679:,:,:] = np.nan
+
+                elif camera_type == "vnir_middle":
+                    print("...%s (subset)" % name)
+                    dst[name][:662,:,:] = rfl_data
+                    # 679-955 set to NaN
+                    print("...NaNs")
+                    dst[name][662:,:,:] = np.nan
+                else:
+                    print("...%s" % name)
+                    dst[name][:] = rfl_data
+
+            # copy variable attributes all at once via dictionary
+            dst[name].setncatts(var_dict)
+
+        if 'rfl_img' not in src.variables:
+            print("...adding rfl_img")
+            dst.createVariable("rfl_img", "f4")
+            dst.variables['rfl_img'] = rfl_data
+
+# replace rfl_img variable in netcdf with given matrix
+def update_netcdf_band(inp, band, band_data, camera_type):
+    if band % 10 == 0:
+        print("band: %s" % band)
+
+    if camera_type=='vnir_old':
+        inp["rfl_img"][band,:,:] = band_data
+    elif camera_type == "vnir_middle":
+        inp["rfl_img"][band,:,:] = band_data
+    else:
+        inp["rfl_img"][band,:,:] = band_data
+
+
+# apply calibration algorithm to the raw data
+def apply_calibration(raw_filepath):
+    print("Calibrating %s" % raw_filepath)
+
+    # get necessary paths from path to _raw file
+    raw_dir = os.path.dirname(raw_filepath)
+    raw_file = os.path.basename(raw_filepath)
+    md_file = os.path.join(raw_dir, "%s_metadata.json" % raw_file[:-4])
+    date = raw_filepath.split("/")[-3]
+    timestamp = raw_filepath.split("/")[-2]
+    envlog_dir   = os.path.join(raw_root, "EnvironmentLogger/%s" % date)
+
+    #     prepare output paths
+    print("Generating output")
+    out_path = os.path.dirname(raw_filepath.replace("raw_data", "Level_1").replace("SWIR", "swir_netcdf").replace("VNIR", "vnir_netcdf"))
+    if not os.path.isdir(out_path):
+        os.makedirs(out_path)
+    if os.path.isfile(out_path):
+        print("Output file already exists: skipping "+out_path)
+        return
+
+    # determine type of sensor and age of camera
+    if raw_filepath.find("VNIR") > -1:
+        if date < "2018-08-18":
+            camera_type = "vnir_old"
+            num_spectral_bands = 955
+            num_bands_irradiance = 1024
+            image_scanning_time   =  540
+        elif "2018-08-18" <= date < "2019-02-26":
+            camera_type = "vnir_middle"
+            num_spectral_bands = 939
+            num_bands_irradiance = 1024
+            image_scanning_time   =  540
+        else:
+            camera_type = "vnir_new"
+            num_spectral_bands = 939
+            num_bands_irradiance = 3648
+            # it is obverved that it takes an average of 3.5 mins/scan  = 210 seconds
+            image_scanning_time   =  210
+    else:
+        if date < "2019-02-26": # Note that no calibration models are available for old&middle swir data
+            camera_type = "swir_old_middle"
+        else:
+            camera_type = "swir_new"
+            num_spectral_bands = 275
+            num_bands_irradiance = 512
+            image_scanning_time   =  210
+
+    print("MODE: ---------- %s ----------" % camera_type)
+
+    # load the raw data set
+    print("Loading %s.hdr" % raw_filepath)
+    try:
+        raw = envi.open(raw_filepath +'.hdr')
+        #        img_DN  = raw.load()
+        img_DN = raw.open_memmap()
+        #head_file = envi.read_envi_header(data_fullpath +'.hdr')
+    except IOError:
+        print('No such file named %s' % raw_filepath)
+
+    # Apply calibration procedure if camera_type == vnir_old, vnir_middle, vnir_new or swir_new. Since no calibration models are available for
+    # swir_old and swir_middle, so directly convert old&middel SWIR raw data to netcdf format
+    if camera_type =="swir_old_middle":
+        # Convert the raw swir_old and swir_middle data to netCDF
+        img_DN = np.rollaxis(img_DN, 2, 0)
+        # Generate output path and call the netCDF conversion function, convert the raw old&middle swir data to netcdf
+        out_path = os.path.dirname(raw_filepath.replace("raw_data", "Level_1").replace("SWIR", "swir_netcdf").replace("VNIR", "vnir_netcdf"))
+        out_file = os.path.join(out_path, "%s_netcdf_L1_ua-mac_%s.nc" % (camera_type.split("_")[0], timestamp))
+        update_netcdf(out_file, img_DN, camera_type)
+
+        # free up memory
+        del img_DN
+
+    else: # when camera_type == vnir_old, vnir_middle, vnir_new or swir_new, apply pre-computed calibration models
+        # Load the previously created calibration models based on the camera_type
+        best_matched = os.path.join(calib_root + "/" + "calibration_new", camera_type, 'best_matched_index.npy')
+        bias = os.path.join(calib_root + "/" + "calibration_new", camera_type, 'bias_coeff.npy')
+        gain = os.path.join(calib_root + "/" + "calibration_new", camera_type, 'gain_coeff.npy')
+        # read EnvLog data
+        print("Reading EnvLog files in %s" % envlog_dir)
+        envlog_tot_time =  []
+        envlog_spectra = np.array([], dtype=np.int64).reshape(0, num_bands_irradiance)
+        for ef in os.listdir(envlog_dir):
+            if ef.endswith("environmentlogger.json"):
+                time, spectrum = irradiance_time_extractor(camera_type,os.path.join(envlog_dir, ef))
+                envlog_tot_time += time
+                # print("concatenating %s onto %s" % (spectrum.shape, envlog_spectra.shape))
+                envlog_spectra = np.vstack([envlog_spectra, spectrum])
+
+        # Find the best match time range between image time stamp and EnvLog time stamp
+        num_irridiance_record = int(image_scanning_time/5)   # 210/5=4.2  ---->  5 seconds per record
+
+        # concatenation of hour mins and seconds of the image time stamp (eg., 12-38-49 to 123849)
+        with open(md_file) as json_file:
+            img_meta_data = json.load(json_file)
+        meta_data_time = img_meta_data['lemnatec_measurement_metadata']['gantry_system_variable_metadata']['time']
+        image_time     = meta_data_time[-8:]
+        image_time     = int(image_time.replace(":",""))
+
+        # compute the absolute difference between
+        print("Computing mean spectrum")
+        abs_diff_time = np.zeros((len(envlog_tot_time)))
+        for k in range(len(envlog_tot_time)):
+            abs_diff_time[k] = abs(image_time  - envlog_tot_time[k])
+        ind_closet_time = np.argmin(abs_diff_time)  # closest time index
+        mean_spectrum  = np.mean(envlog_spectra[ind_closet_time : ind_closet_time + num_irridiance_record-1, :], axis=0)
+
+        # load pre-computed the best matched index between image and irradiance sensor spectral bands
+        best_matched_index = np.load(best_matched)
+        test_irridance     =  mean_spectrum[best_matched_index.astype(int).tolist()]
+        test_irridance_re  = np.resize(test_irridance, (1, num_spectral_bands))
+
+        # load and apply precomputed coefficient to convert irradiance to DN
+        b = np.load(bias)
+        g = np.load(gain)
+        if camera_type == "vnir_old":
+            test_irridance_re = test_irridance_re[:,0:679]
+            img_DN = img_DN[:,:,0:679]
+        if camera_type == "vnir_middle":
+            test_irridance_re = test_irridance_re[:,0:662]
+            img_DN = img_DN[:,:,0:662]
+
+        irrad2DN = (g * test_irridance_re) + b
+
+        # reflectance computation
+        out_file = os.path.join(out_path, "%s_netcdf_L1_ua-mac_%s.nc" % (camera_type.split("_")[0], timestamp))
+        print("Computing reflectance and updating %s" % out_file)
+        with Dataset(out_file, 'a', mmap=False) as src:
+            for band_ind in range(img_DN.shape[2]):
+                calibrated_band = img_DN[:,:,band_ind] / irrad2DN[:,band_ind]
+                calibrated_band = np.swapaxes(calibrated_band, 0, 1)
+                update_netcdf_band(src, band_ind, calibrated_band, camera_type)
+
+        print("All done")
+
+        # save as ENVI file (RGB bands: 392, 252, 127)
+        # VNIR - 376 (R) 235 (G) 95 (B)
+        out_file = os.path.join('ref_%s.hdr' % raw_file)
+        envi.save_image(out_file, Ref, dtype=np.float32, interleave='bil', force = 'True', metadata=head_file)
+
+
+if __name__ == "__main__":
+    # TODO: This will come from the extractor message
+    input_paths = [
+        os.path.join(raw_root, "VNIR/2019-05-23/2019-05-23__13-52-42-629/47265f0b-7a51-43a3-8f7a-bdf11bd6fe38_raw"),
+        #os.path.join(raw_root, "VNIR/2018-08-18/2018-08-18__11-11-41-890/c5f4d50f-44ad-4e23-9d92-f10e62110ac7_raw"),
+    ]
+
+    for p in input_paths:
+        create_empty_netCDF(p)
+        apply_calibration(p)
+

--- a/hyperspectral/hyperspectral_calculation.py
+++ b/hyperspectral/hyperspectral_calculation.py
@@ -239,17 +239,22 @@ def pixel2Geographic(metadata, hdr_path, camera_type):
             y_final_result = np.array([y * y_pixel_size for y in range(y_pixel_num)]) + y_absolute_pos
         else:
             y_final_result = np.array([y * 2 * y_pixel_size for y in range(y_pixel_num)]) + y_absolute_pos
+        # Determine 4 corners of bounding box
+        SE = (x_final_result[0]  * LATITUDE_TO_METER + origin_x, -(y_final_result[0])  * LONGITUDE_TO_METER + origin_y)
+        SW = (x_final_result[0]  * LATITUDE_TO_METER + origin_x, -(y_final_result[-1]) * LONGITUDE_TO_METER + origin_y)
+        NE = (x_final_result[-1] * LATITUDE_TO_METER + origin_x, -(y_final_result[0])  * LONGITUDE_TO_METER + origin_y)
+        NW = (x_final_result[-1] * LATITUDE_TO_METER + origin_x, -(y_final_result[-1]) * LONGITUDE_TO_METER + origin_y)
+
     else:
         if not downsampled:
             y_final_result = np.array([-y * y_pixel_size for y in range(y_pixel_num)]) + y_absolute_pos
         else:
             y_final_result = np.array([-y * 2 * y_pixel_size for y in range(y_pixel_num)]) + y_absolute_pos
-
-    # Determine 4 corners of bounding box
-    SE = (x_final_result[0]  * LATITUDE_TO_METER + origin_x, -(y_final_result[0])  * LONGITUDE_TO_METER + origin_y)
-    SW = (x_final_result[0]  * LATITUDE_TO_METER + origin_x, -(y_final_result[-1]) * LONGITUDE_TO_METER + origin_y)
-    NE = (x_final_result[-1] * LATITUDE_TO_METER + origin_x, -(y_final_result[0])  * LONGITUDE_TO_METER + origin_y)
-    NW = (x_final_result[-1] * LATITUDE_TO_METER + origin_x, -(y_final_result[-1]) * LONGITUDE_TO_METER + origin_y)
+        # Determine 4 corners of bounding box
+        SE = (x_final_result[0]  * LATITUDE_TO_METER + origin_x, -(y_final_result[-1])  * LONGITUDE_TO_METER + origin_y)
+        SW = (x_final_result[0]  * LATITUDE_TO_METER + origin_x, -(y_final_result[0]) * LONGITUDE_TO_METER + origin_y)
+        NE = (x_final_result[-1] * LATITUDE_TO_METER + origin_x, -(y_final_result[-1])  * LONGITUDE_TO_METER + origin_y)
+        NW = (x_final_result[-1] * LATITUDE_TO_METER + origin_x, -(y_final_result[0]) * LONGITUDE_TO_METER + origin_y)
 
     j_bbox = generate_geojson(SE, SW, NE, NW)
 

--- a/hyperspectral/hyperspectral_calculation.py
+++ b/hyperspectral/hyperspectral_calculation.py
@@ -1,171 +1,269 @@
 # -*- coding: utf-8 -*-
-
 import numpy as np
-import sys
+import os
 import json
 from math import *
 from datetime import date, datetime, timedelta
 from decimal import *
 
-# from Dr. LeBauer, Github thread: terraref/referece-data #32
-CAMERA_POSITION = np.array([1.9, 0.855, 0.635])
-
-# from Dr. LeBauer, Github thread: terraref/referece-data #32
-CAMERA_FOCAL_LENGTH = 24e-3 # the focal length for SWIR camera. unit:[m]
-
-# from Dr. LeBauer, Github thread: terraref/referece-data #32
-PIXEL_PITCH = 25e-6 #[m]
-
-REFERENCE_POINT = 33 + 4.47 / 60, -111 - 58.485 / 60 # from https://github.com/terraref/reference-data/issues/32
-
-LONGITUDE_TO_METER = 1 / (30.87 * 3600)
-LATITUDE_TO_METER  = 1/ (25.906 * 3600) #varies, but has been corrected based on the actural location of the field
-
-GOOGLE_MAP_TEMPLATE = "https://maps.googleapis.com/maps/api/staticmap?size=1280x720&zoom=17&path=color:0x0000005|weight:5|fillcolor:0xFFFF0033|{pointA}|{pointB}|{pointC}|{pointD}"
+from terrautils.spatial import scanalyzer_to_latlon
 
 
-def _julian_date(time_date):
-    '''
-    Calculate the Julian Date based on the input datetime object (should
-    be in Gregorian).
-    
-    Private in this module
+LATITUDE_TO_METER = 1 / (30.87 * 3600)
+LONGITUDE_TO_METER  = 1 / (25.906 * 3600) # varies, but has been corrected based on the actual location of the field
 
-    Had already checked the output against the result from
-    United States Naval Observatory, Astronomical App Dept.
-    
-    Detail: http://aa.usno.navy.mil/data/docs/JulianDate.php
-    '''
-    a = floor((14-time_date.month)/12)
-    
-    if time_date.month in (1, 2):
-        assert a == 1
+
+# --- TESTING FUNCTIONS - DON'T HARDCODE FOR PRODUCTION ---
+def get_VNIR_fixed_metadata(date):
+    """Normally, this is included in the cleaned metadata that terrautils will generate, using the Github fixed
+        metadata repo as a source.
+
+        I'm copying this code to this test file for convenience so we can test using the raw metadata file without
+        cleaning it first. Only fields that this code might use is included.
+
+        Numbers from: https://github.com/terraref/sensor-metadata/blob/master/sensors/VNIR/sensor_fixed_metadata.json
+        Cleaning code: https://github.com/terraref/terrautils/blob/master/terrautils/lemnatec.py#L169
+    """
+
+    # New camera
+    if date >= "2018-08-18":
+        md = {
+            "location_in_camera_box_m": {
+                "x": "0.867",
+                "y": "1.663",
+                "z": "0.635"
+            },
+            "field_of_view_degrees": {
+                "y": "21.0"
+            }
+        }
+    # Old camera
     else:
-        assert a == 0
-        
-    years  = time_date.year + 4800 - a
-    months = time_date.month + 12 * a - 3
-    
-    if time_date.month == 3:
-        assert months == 0
-    elif time_date.month == 2:
-        assert months == 11
-    
-    getcontext().prec = 8
-    return time_date.day  + floor((153*months+2)/5) + 365*years +\
-           floor(years/4) - floor(years/100) + floor(years/400) - 32045 +\
-           float(Decimal(time_date.hour-12)/Decimal(24) + Decimal(time_date.minute)/Decimal(1440)+\
-           Decimal(time_date.second)/Decimal(86400))
-        
-        
+        md = {
+            "location_in_camera_box_m": {
+                "x": "0.877",
+                "y": "2.325",
+                "z": "0.635"
+            },
+            "field_of_view_degrees": {
+                "y": "21.0"
+            }
+        }
+
+    return md
+
+def get_SWIR_fixed_metadata(date):
+    """Normally, this is included in the cleaned metadata that terrautils will generate, using the Github fixed
+        metadata repo as a source.
+
+        I'm copying this code to this test file for convenience so we can test using the raw metadata file without
+        cleaning it first. Only fields that this code might use is included.
+
+        Numbers from: https://github.com/terraref/sensor-metadata/blob/master/sensors/SWIR/sensor_fixed_metadata.json
+        Cleaning code: https://github.com/terraref/terrautils/blob/master/terrautils/lemnatec.py#L169
+    """
+
+    # New camera
+    if date >= "2018-08-18":
+        md = {
+            "location_in_camera_box_m": {
+                "x": "0.495",
+                "y": "1.875",
+                "z": "0.635"
+            },
+            "field_of_view_degrees": {
+                "y": "44.5"
+            }
+        }
+    # Old camera
+    else:
+        md = {
+            "location_in_camera_box_m": {
+                "x": "0.877",
+                "y": "2.325",
+                "z": "0.635"
+            },
+            "field_of_view_degrees": {
+                "y": "44.5"
+            }
+        }
+
+    return md
+
+def generate_geojson(SE, SW, NE, NW):
+    # Create a geojson file for viewing e.g. in QGIS
+    return {
+        "type": "Polygon",
+        "coordinates": [[
+            [NE[1], NE[0]],
+            [NW[1], NW[0]],
+            [SW[1], SW[0]],
+            [SE[1], SE[0]],
+            [NE[1], NE[0]] # repeat final coordinate
+        ]]
+    }
+
+def test_pixel2Geographic(json_path, hdr_path, camera_type):
+    # operates off raw json md file instead of cleaned metadata in pipeline
+    synthetic_metadata = {}
+
+    # ----- GET FIXED METADATA -----
+    date = hdr_path.split("/")[-3]
+    timestamp = hdr_path.split("/")[-2]
+    if camera_type == "SWIR":
+        synthetic_metadata['sensor_fixed_metadata'] = get_SWIR_fixed_metadata(date)
+    else:
+        synthetic_metadata['sensor_fixed_metadata'] = get_VNIR_fixed_metadata(date)
+
+    # ----- GET VARIABLE METADATA -----
+    with open(json_path) as json_meta:
+        meta = json.loads(json_meta.read())["lemnatec_measurement_metadata"]
+    x_gantry_pos, y_gantry_pos = None, None
+    # For scans east-to-west, the captured position is in the southeast.
+    # For scans west-to-east, the captured position is the southwest.
+    for pos_field in ["position x [m]", "Position x [m]"]:
+        if pos_field in meta["gantry_system_variable_metadata"]:
+            x_gantry_pos = float(meta["gantry_system_variable_metadata"][pos_field])
+            y_gantry_pos = float(meta["gantry_system_variable_metadata"][pos_field.replace("x", "y")])
+            break
+
+    synthetic_metadata['gantry_variable_metadata'] = {
+        'position_m': {
+            'x': x_gantry_pos,
+            'y': y_gantry_pos
+        },
+        'scan_direction_is_positive': str(meta["gantry_system_variable_metadata"]["scanDirectionIsPositive"]),
+        'scan_speed_m/s': float(meta["gantry_system_variable_metadata"]["scanSpeedInMPerS [m/s]"])
+    }
+    synthetic_metadata['sensor_variable_metadata'] = {
+        'frame_period': int(meta["sensor_variable_metadata"]["current setting frameperiod"])
+    }
+
+    out = pixel2Geographic(synthetic_metadata, hdr_path, camera_type)
+
+    out_path = "/home/extractor/hs_calib/VNIR/2019-07-25/geojson/%s.geojson" % timestamp
+    with open(out_path, 'w') as shpfile:
+        json.dump(out['bbox_geojson'], shpfile)
+
+    return out
+
+# ----------------- END TESTING FUNCTIONS -----------------
+
 def solar_zenith_angle(time_date):
 
     latitude = 33 + 4.47 / 60
-    
-    days_offset       = time_date - datetime(year=time_date.year,month=1,day=1) +\
+
+    days_offset       = time_date - datetime(year=time_date.year,month=1,day=1) + \
                         timedelta(days=1)
-    numerical_cal_day = Decimal(days_offset.days) + Decimal(days_offset.seconds) /\
+    numerical_cal_day = Decimal(days_offset.days) + Decimal(days_offset.seconds) / \
                         Decimal(86340)
-    
+
     theta = Decimal(2)*Decimal(pi)*numerical_cal_day/Decimal(365)
-    
-    eccentricity_fac = Decimal(1.000110)+\
-                       Decimal(cos(theta))*Decimal(0.034221)+\
-                       Decimal(sin(theta))*Decimal(0.001280)+\
-                       Decimal(cos(Decimal(2)*theta))*Decimal(0.000719)+\
+
+    eccentricity_fac = Decimal(1.000110)+ \
+                       Decimal(cos(theta))*Decimal(0.034221)+ \
+                       Decimal(sin(theta))*Decimal(0.001280)+ \
+                       Decimal(cos(Decimal(2)*theta))*Decimal(0.000719)+ \
                        Decimal(sin(Decimal(2)*theta))*Decimal(0.000077)
-    
-    solar_decline    = Decimal(0.006918) - Decimal(0.399912)*Decimal(cos(theta))+\
-                                           Decimal(0.070257)*Decimal(sin(theta))-\
-                                           Decimal(0.006758)*Decimal(cos(Decimal(2)*theta))+\
-                                           Decimal(0.000907)*Decimal(sin(Decimal(2)*theta))-\
-                                           Decimal(0.002697)*Decimal(cos(Decimal(3)*theta))+\
-                                           Decimal(0.001480)*Decimal(sin(Decimal(3)*theta))
-                        
+
+    solar_decline    = Decimal(0.006918) - Decimal(0.399912)*Decimal(cos(theta))+ \
+                       Decimal(0.070257)*Decimal(sin(theta))- \
+                       Decimal(0.006758)*Decimal(cos(Decimal(2)*theta))+ \
+                       Decimal(0.000907)*Decimal(sin(Decimal(2)*theta))- \
+                       Decimal(0.002697)*Decimal(cos(Decimal(3)*theta))+ \
+                       Decimal(0.001480)*Decimal(sin(Decimal(3)*theta))
+
     sin_latitude     = Decimal(sin(radians(latitude)))
     sin_delta        = Decimal(sin(solar_decline))
     cos_latitude     = Decimal(cos(radians(latitude)))
     cos_delta        = Decimal(cos(solar_decline))
-    
+
     cphase = Decimal(cos(Decimal(2*pi)*numerical_cal_day))
     cos_solar_zen_ang = sin_latitude*sin_delta-cos_latitude*cos_delta*cphase
-    
+
     return float(Decimal(acos(cos_solar_zen_ang)/pi)*Decimal(180))
 
+def pixel2Geographic(metadata, hdr_path, camera_type):
 
-def pixel2Geographic(jsonFileLocation, headerFileLocation, cameraOption, downsampled=False):
+    # ----- PREPARE METADATA -----
+    # TODO: store this in fixed metadata
+    if camera_type == "SWIR":
+        x_pixel_size = 1.930615052e-3
+    else:
+        x_pixel_size = 1.025e-3
+    y_pixel_size = 0.98526434004512529576754637665e-3
 
-    ######################### Load necessary data #########################
-    with open(jsonFileLocation) as fileHandler:
-        master = json.loads(fileHandler.read())["lemnatec_measurement_metadata"]
+    if 'scan_speed_m/s' in metadata['gantry_variable_metadata']:
+        scan_speed = metadata['gantry_variable_metadata']['scan_speed_m/s']
+        framepd = metadata['sensor_variable_metadata']['frame_period']
+        downsampled = (scan_speed == 0.04 and framepd > 25)
+    else:
+        downsampled = False
 
-        if "position x [m]" in master["gantry_system_variable_metadata"]:
-            x_gantry_pos = float(master["gantry_system_variable_metadata"]["position x [m]"])
-            y_gantry_pos = float(master["gantry_system_variable_metadata"]["position y [m]"])
+    x_camera_pos = float(metadata['sensor_fixed_metadata']["location_in_camera_box_m"]["x"])
+    y_camera_pos = float(metadata['sensor_fixed_metadata']["location_in_camera_box_m"]["y"])
+    x_gantry_pos = float(metadata['gantry_variable_metadata']["position_m"]["x"])
+    y_gantry_pos = float(metadata['gantry_variable_metadata']["position_m"]["y"])
+    scan_dir = str(metadata['gantry_variable_metadata']["scan_direction_is_positive"])
 
-        elif "Position x [m]" in master["gantry_system_variable_metadata"]:
-            x_gantry_pos = float(master["gantry_system_variable_metadata"]["Position x [m]"])
-            y_gantry_pos = float(master["gantry_system_variable_metadata"]["Position y [m]"])
+    # ----- GET HDR METADATA -----
+    with open(hdr_path) as hdr_data:
+        overall = hdr_data.readlines()
+    for members in overall:
+        if "samples" in members:
+            x_pixel_num = int(members.split("=")[-1].strip("\n"))
+        if "lines" in members:
+            y_pixel_num = int(members.split("=")[-1].strip("\n"))
 
-        else: # We notice that there are cases that no position data available
-            return {"x_coordinates": None,
-                    "y_coordinates": None,
-                    "latitudes"    : None,
-                    "longitudes"   : None,
-                    "bounding_box" : None,
-                    "Google_Map"   : None}
+    # ----- GET ORIGIN POINT -----
+    REFERENCE_POINT = scanalyzer_to_latlon(0,0) # SE corner of the field latlon coordinates
+    origin_x = REFERENCE_POINT[0]
+    origin_y = REFERENCE_POINT[1]
 
-        x_camera_pos = 1.9 # From https://github.com/terraref/reference-data/issues/32
-        y_camera_pos = 0.855
+    # ----- CALCULATE POSITIONS -----
+    x_absolute_pos = x_gantry_pos + x_camera_pos
+    y_absolute_pos = y_gantry_pos + y_camera_pos
 
-        if cameraOption == "SWIR":
-            x_pixel_size = 1.930615052e-3
+    x_final_result = []
+    x_half_px = x_pixel_num/2
+    for x in range(x_pixel_num):
+        if x <= x_half_px:
+            x_final_result_value = x_absolute_pos + ((-x+x_half_px) * -x_pixel_size)
         else:
-            x_pixel_size = 1.025e-3
+            x_final_result_value = x_absolute_pos + ((x-x_half_px) * x_pixel_size)
+        x_final_result.append(x_final_result_value)
+    x_final_result = np.array(x_final_result)
 
-        y_pixel_size = 0.98526434004512529576754637665e-3
-
-        with open(headerFileLocation) as fileHandler:
-            overall = fileHandler.readlines()
-
-            for members in overall:
-                if "samples" in members:
-                    x_pixel_num = int(members.split("=")[-1].strip("\n"))
-                elif "lines" in members:
-                    y_pixel_num = int(members.split("=")[-1].strip("\n"))
-
-
-        ######################### Do calculation #########################
-
-        x_absolute_pos = x_gantry_pos + x_camera_pos
-        y_absolute_pos = y_gantry_pos + y_camera_pos
-
-        x_final_result = np.array([x * x_pixel_size for x in range(x_pixel_num)]) + x_absolute_pos
-
+    if scan_dir == "True":
         if not downsampled:
             y_final_result = np.array([y * y_pixel_size for y in range(y_pixel_num)]) + y_absolute_pos
         else:
             y_final_result = np.array([y * 2 * y_pixel_size for y in range(y_pixel_num)]) + y_absolute_pos
+    else:
+        if not downsampled:
+            y_final_result = np.array([-y * y_pixel_size for y in range(y_pixel_num)]) + y_absolute_pos
+        else:
+            y_final_result = np.array([-y * 2 * y_pixel_size for y in range(y_pixel_num)]) + y_absolute_pos
 
-        ########### Sample result: x -> 0.377 [m], y -> 0.267 [m] ###########
+    # Determine 4 corners of bounding box
+    SE = (x_final_result[0]  * LATITUDE_TO_METER + origin_x, -(y_final_result[0])  * LONGITUDE_TO_METER + origin_y)
+    SW = (x_final_result[0]  * LATITUDE_TO_METER + origin_x, -(y_final_result[-1]) * LONGITUDE_TO_METER + origin_y)
+    NE = (x_final_result[-1] * LATITUDE_TO_METER + origin_x, -(y_final_result[0])  * LONGITUDE_TO_METER + origin_y)
+    NW = (x_final_result[-1] * LATITUDE_TO_METER + origin_x, -(y_final_result[-1]) * LONGITUDE_TO_METER + origin_y)
 
-        SE = x_final_result[-1] * LONGITUDE_TO_METER + REFERENCE_POINT[0], y_final_result[-1] * LATITUDE_TO_METER + REFERENCE_POINT[1]
-        SW = x_final_result[0] * LONGITUDE_TO_METER  + REFERENCE_POINT[0], y_final_result[-1] * LATITUDE_TO_METER + REFERENCE_POINT[1]
-        NE = x_final_result[-1] * LONGITUDE_TO_METER + REFERENCE_POINT[0], y_final_result[0]  * LATITUDE_TO_METER + REFERENCE_POINT[1]
-        NW = x_final_result[0] * LONGITUDE_TO_METER + REFERENCE_POINT[0] , y_final_result[0]  * LATITUDE_TO_METER + REFERENCE_POINT[1]
+    j_bbox = generate_geojson(SE, SW, NE, NW)
 
-        bounding_box = (str(SE).strip("()"), str(SW).strip("()"), str(NE).strip("()"), str(NW).strip("()"))
-        bounding_box_mapview = GOOGLE_MAP_TEMPLATE.format(pointA=bounding_box[0],
-                                                          pointB=bounding_box[1],
-                                                          pointC=bounding_box[2],
-                                                          pointD=bounding_box[3])
+    lat_final_result = np.array([x * LATITUDE_TO_METER  for x in x_final_result]) + origin_x
+    lon_final_result = np.array([-y * LONGITUDE_TO_METER for y in y_final_result]) + origin_y
+    bounding_box = (str(SE).strip("()"), str(SW).strip("()"), str(NE).strip("()"), str(NW).strip("()"))
 
-        lat_final_result = np.array([x * LATITUDE_TO_METER for x in x_final_result])  + REFERENCE_POINT[0]
-        lon_final_result = np.array([-y * LONGITUDE_TO_METER for y in y_final_result]) + REFERENCE_POINT[1]
-
-        return {"x_coordinates": x_final_result,
-                "y_coordinates": y_final_result,
-                "latitudes"    : lat_final_result,
-                "longitudes"   : lon_final_result,
-                "bounding_box" : bounding_box,
-                "Google_Map"   : bounding_box_mapview}
+    return {"x_coordinates": x_final_result,
+            "y_coordinates": y_final_result,
+            "x_pixel_size" : x_pixel_size,
+            "y_pixel_size" : y_pixel_size,
+            "x_reference"  : origin_x,
+            "y_reference"  : origin_y,
+            "latitudes"    : lat_final_result,
+            "longitudes"   : lon_final_result,
+            "bounding_box" : bounding_box,
+            "bbox_geojson" : j_bbox}

--- a/hyperspectral/hyperspectral_calculation.py
+++ b/hyperspectral/hyperspectral_calculation.py
@@ -103,7 +103,7 @@ def generate_geojson(SE, SW, NE, NW):
         ]]
     }
 
-def test_pixel2Geographic(json_path, hdr_path, camera_type):
+def test_pixel2Geographic(json_path, hdr_path, camera_type, out_path=None):
     # operates off raw json md file instead of cleaned metadata in pipeline
     synthetic_metadata = {}
 
@@ -141,7 +141,8 @@ def test_pixel2Geographic(json_path, hdr_path, camera_type):
 
     out = pixel2Geographic(synthetic_metadata, hdr_path, camera_type)
 
-    out_path = "/home/extractor/hs_calib/VNIR/2019-07-25/geojson/%s.geojson" % timestamp
+    if out_path is None:
+        out_path = "/home/extractor/hs_calib/VNIR/2019-07-25/geojson/%s.geojson" % timestamp
     with open(out_path, 'w') as shpfile:
         json.dump(out['bbox_geojson'], shpfile)
 


### PR DESCRIPTION
Significant changes here, the result of several hackathons and collaborative effort to improve this extractor. Key changes:

- hyperspectral_workflow.sh script is not currently used anymore.
- python code is used to create empty netCDF file with appropriate headers. this empty file is then populated with the calibrated reflectance data once ready.
- calibrated reflectance data is written to file per-band, which should avoid the memory problems this extractor has had in the past and allow processing of all files.
- georeferencing of hyperspectral is corrected, not using terrautils still because it requires data from the .hdr file that terrautils is not prepared to locate in cleaning process.

So hyperspectral_calculation.py has the georeferencing code, calibrate.py creates empty netCDF, does calibration, calls georeference code, adds it all to headers.

THIS NEEDS MORE TESTING BEFORE I MERGE but should just be fixing bugs, not major changes. In separate pieces, all code has been tested.